### PR TITLE
Fix keep going test

### DIFF
--- a/tests/test_micropip.py
+++ b/tests/test_micropip.py
@@ -89,8 +89,10 @@ def make_wheel_filename(name: str, version: str, platform: str = "generic") -> s
         platform_str = "py3-none-any"
     elif platform == "emscripten":
         platform_str = f"{cpver}-{cpver}-{_platform()}"
-    elif platform == "native":
+    elif platform == "linux":
         platform_str = f"{cpver}-{cpver}-manylinux_2_31_x86_64"
+    elif platform == "windows":
+        platform_str = f"{cpver}-{cpver}-win_amd64"
     else:
         platform_str = platform
 
@@ -547,8 +549,8 @@ async def test_install_keep_going(mock_fetch: mock_fetch_cls) -> None:
     dep1 = "dep1"
     dep2 = "dep2"
     mock_fetch.add_pkg_version(dummy, requirements=[dep1, dep2])
-    mock_fetch.add_pkg_version(dep1, platform="native")
-    mock_fetch.add_pkg_version(dep2, platform="native")
+    mock_fetch.add_pkg_version(dep1, platform="windows")
+    mock_fetch.add_pkg_version(dep2, platform="windows")
 
     # report order is non-deterministic
     msg = f"({dep1}|{dep2}).*({dep2}|{dep1})"

--- a/tests/test_micropip.py
+++ b/tests/test_micropip.py
@@ -93,6 +93,8 @@ def make_wheel_filename(name: str, version: str, platform: str = "generic") -> s
         platform_str = f"{cpver}-{cpver}-manylinux_2_31_x86_64"
     elif platform == "windows":
         platform_str = f"{cpver}-{cpver}-win_amd64"
+    elif platform == "invalid":
+        platform_str = f"{cpver}-{cpver}-invalid"
     else:
         platform_str = platform
 
@@ -549,8 +551,8 @@ async def test_install_keep_going(mock_fetch: mock_fetch_cls) -> None:
     dep1 = "dep1"
     dep2 = "dep2"
     mock_fetch.add_pkg_version(dummy, requirements=[dep1, dep2])
-    mock_fetch.add_pkg_version(dep1, platform="windows")
-    mock_fetch.add_pkg_version(dep2, platform="windows")
+    mock_fetch.add_pkg_version(dep1, platform="invalid")
+    mock_fetch.add_pkg_version(dep2, platform="invalid")
 
     # report order is non-deterministic
     msg = f"({dep1}|{dep2}).*({dep2}|{dep1})"

--- a/tests/test_micropip.py
+++ b/tests/test_micropip.py
@@ -541,7 +541,6 @@ def test_install_mixed_case2(selenium_standalone_micropip, jinja2):
     )
 
 
-@pytest.mark.xfail(reason="test fails in some environments")
 @pytest.mark.asyncio
 async def test_install_keep_going(mock_fetch: mock_fetch_cls) -> None:
     dummy = "dummy"


### PR DESCRIPTION
Close: #11

The test was failing because when running host test, micropip accepts manylinux wheels.