### PR TITLE
Option to skip selected dependencies

### DIFF
--- a/micropip/_micropip.py
+++ b/micropip/_micropip.py
@@ -447,7 +447,7 @@ async def install(
     deps: bool = True,
     credentials: str | None = None,
     pre: bool = False,
-    skip_deps: list[str]=[],
+    skip_deps: list[str] = [],
 ) -> None:
     """Install the given package and all of its dependencies.
 
@@ -521,7 +521,7 @@ async def install(
 
     skip_deps: ``Optional[list[str]]``
 
-        This parameter specifies a list of packages which should not be installed 
+        This parameter specifies a list of packages which should not be installed
         if they are in the dependency tree.
 
     Returns
@@ -554,7 +554,7 @@ async def install(
         deps=deps,
         pre=pre,
         fetch_kwargs=fetch_kwargs,
-        skip_deps=skip_deps
+        skip_deps=skip_deps,
     )
     await transaction.gather_requirements(requirements)
 


### PR DESCRIPTION
Many packages include dependencies which are only used in some cases. e.g. I've got some packages which include a load of jupyter server stuff as deps, which can be ignored in pyodide. 

This patch lets you skip some dependencies if you don't want to get them, whilst still getting other deps with micropip.