### PR TITLE
Fixed wheel choice by interpreter version tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for adding mock packages, for use where something is a dependency and you don't need it, or you need only a limited subset of the package. This is done using `micropip.add_mock_package`, `micropip.remove_mock_package` and `micropip.list_mock_packages`. Packages installed like this will be skipped by dependency resolution when you later install real packages.
 
+### Fixed
+
+- When multiple compatible builds for a package exist, the best
+  build is now installed, as determined by the order of tags in
+  [`packaging.tags.sys_tags`](https://packaging.pypa.io/en/latest/tags.html#packaging.tags.sys_tags).
+  For example, if a package has two pure Python wheels, one tagged `py30` and
+  another tagged `py35`, the `py35` wheel will now always get installed.
+  [#34](https://github.com/pyodide/micropip/pull/34)
+
 ## [0.1.0] - 2022/09/18
 
 Initial standalone release. For earlier release notes, see


### PR DESCRIPTION
Fixes #32 .

There seem to be *unrelated* test failures *already* in the automated test suite, but those failures are the same both before and after my patch, and the tests I added (and the one test I changed to factor out some now-reused code) are all passing.