### PR TITLE
Fix minimum Python requirement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 description = "A lightweight Python package installer for the web "
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",


### PR DESCRIPTION
Closes https://github.com/pyodide/micropip/issues/21

We don't need to specify pyparsing explicitly since it's already a dependency of packaging (that is removed in latest version). Adding a CI job just to test requirements is probably too much.