### PR TITLE
Fix deployment CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           fail_ci_if_error: false
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment: PyPi-deploy
     steps:


### PR DESCRIPTION
The deployment CI failed, so I ended up uploading the wheels manually (to avoid doing a post-release version tag).

Meanwhile, this is a fix for the deployment CI.