### PR TITLE
Fix installing underscore-prefixed unvendored stdlib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        pyodide-version: [0.21.3, 0.22.0a3]
+        pyodide-version: [0.22.0a3]
         test-config: [
           {runner: selenium, runtime: chrome, runtime-version: latest },
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - xxxx/xx/xx
+
+### Fixed
+
+- `micropip.install` now correctly installs unvendored standard libraries that has underscore prefix, like _hashlib.
+  [#41](https://github.com/pyodide/micropip/pull/41]
+
 ## [0.2.0] - 2022/12/12
 
 ### Added

--- a/micropip/_micropip.py
+++ b/micropip/_micropip.py
@@ -21,7 +21,7 @@ from zipfile import ZipFile
 
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
-from packaging.specifier import SpecifierSet
+from packaging.specifiers import SpecifierSet
 from packaging.tags import Tag, sys_tags
 from packaging.utils import canonicalize_name, parse_wheel_filename
 from packaging.version import Version

--- a/micropip/_micropip.py
+++ b/micropip/_micropip.py
@@ -354,10 +354,9 @@ class Transaction:
             True if the matching package is found inside the repodata.json file, False otherwise.
         """
 
-        if (
-            name in packages
-            and specifier is not None
-            and specifier.contains(packages[name]["version"], prereleases=True)
+        if name in packages and (
+            specifier is None
+            or specifier.contains(packages[name]["version"], prereleases=True)
         ):
             version = packages[name]["version"]
             self.pyodide_packages.append(

--- a/tests/test_micropip.py
+++ b/tests/test_micropip.py
@@ -877,7 +877,7 @@ def test_list_loaded_from_js(selenium_standalone_micropip):
 
 @pytest.mark.skip_refcount_check
 @run_in_pyodide(packages=["micropip"])
-async def test_install_with_credentials(selenium):
+async def test_install_with_credentials(selenium_standalone_micropip):
     import json
     from unittest.mock import MagicMock, patch
 
@@ -907,7 +907,7 @@ async def test_install_with_credentials(selenium):
 
 @pytest.mark.asyncio
 @run_in_pyodide(packages=["micropip"])
-async def test_install_underscore_stdlib(selenium):
+async def test_install_underscore_stdlib(selenium_standalone_micropip):
     import micropip
 
     await micropip.install("_hashlib")
@@ -926,7 +926,7 @@ async def test_load_binary_wheel1(
 
 @pytest.mark.skip_refcount_check
 @run_in_pyodide(packages=["micropip"])
-async def test_load_binary_wheel2(selenium):
+async def test_load_binary_wheel2(selenium_standalone_micropip):
     from pyodide_js._api import repodata_packages
 
     import micropip

--- a/tests/test_micropip.py
+++ b/tests/test_micropip.py
@@ -889,6 +889,16 @@ async def test_install_with_credentials(selenium):
 
 
 @pytest.mark.asyncio
+@run_in_pyodide(packages=["micropip"])
+async def test_install_underscore_stdlib(selenium):
+    import micropip
+
+    await micropip.install("_hashlib")
+
+    assert "_hashlib" in micropip.list()
+
+
+@pytest.mark.asyncio
 async def test_load_binary_wheel1(
     mock_fetch: mock_fetch_cls, mock_importlib: None, mock_platform: None
 ) -> None:


### PR DESCRIPTION
`micropip.install("_hashlib")` was failing with:

```py
packaging.requirements.InvalidRequirement: Parse error at "'_hashlib'": Expected W:(0-9A-Za-z)
```

as it is not a valid package name. But we actually want to install it as it is unvendored stdlib.
