### PR TITLE
Skip invalid versions on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.2] - 2023/03/04
+
+### Fixed
+
+- When there is an invalid version on PyPi (defined as unparsable
+  by [`packaging.version.Version`](https://packaging.pypa.io/en/stable/version.html))
+  that version is now skipped. Otherwise a single invalid version would
+  make the package uninstallable, following removal of `LegacyVersion` in
+  [packaging#407](https://github.com/pypa/packaging/pull/407).
+
+### Fixed
+
 ## [0.2.1] - 2023/02/20
 
 ### Changed

--- a/micropip/_micropip.py
+++ b/micropip/_micropip.py
@@ -23,7 +23,7 @@ from packaging.markers import default_environment
 from packaging.requirements import Requirement
 from packaging.tags import Tag, sys_tags
 from packaging.utils import canonicalize_name, parse_wheel_filename
-from packaging.version import Version, InvalidVersion
+from packaging.version import InvalidVersion, Version
 
 from . import _mock_package
 from ._compat import (

--- a/tests/test_micropip.py
+++ b/tests/test_micropip.py
@@ -539,6 +539,27 @@ def test_last_version_from_pypi():
     assert str(wheel.version) == "0.15.5"
 
 
+def test_find_wheel_invalid_version():
+    """Check that if the one version on PyPi is unparsable
+
+    it should be skipped instead of producing an error
+    """
+    pytest.importorskip("packaging")
+    from packaging.requirements import Requirement
+
+    from micropip._micropip import find_wheel
+
+    requirement = Requirement("dummy_module")
+    versions = ["0.0.1", "0.15.5", "0.9.1", "2004d"]
+
+    metadata = _pypi_metadata("dummy_module", {v: ["py3"] for v in versions})
+
+    # get version number from find_wheel
+    wheel = find_wheel(metadata, requirement)
+
+    assert str(wheel.version) == "0.15.5"
+
+
 _best_tag_test_cases = (
     "package, version, incompatible_tags, compatible_tags",
     # Tests assume that `compatible_tags` is sorted from least to most compatible:


### PR DESCRIPTION
With this change, micropip would skip invalid versions (those that cannot be parsed with [packaging.version.Version](https://packaging.pypa.io/en/stable/version.html#version-handling)) when looking at available versions on PyPi.

Otherwise, with lastest `packaging` the current situation is to error, when there is even one invalid version in the list as was the case with pytz in 2004 in https://github.com/pyodide/pyodide/pull/3605#issuecomment-1442612037