### PR TITLE
Add verbose option to install and uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `verbose` parameter to micropip.install and micropip.uninstall
+  [#60](https://github.com/pyodide/micropip/pull/60)
+
 ## [0.3.0] - 2023/03/29
 
 ### Added

--- a/micropip/_commands/install.py
+++ b/micropip/_commands/install.py
@@ -89,7 +89,7 @@ async def install(
     verbose :
         Print more information about the process.
         By default, micropip is silent. Setting ``verbose=True`` will print
-        mostly the same information as pip.
+        similar information as pip.
     """
     logger = setup_logging(verbose)
 

--- a/micropip/_commands/install.py
+++ b/micropip/_commands/install.py
@@ -130,7 +130,9 @@ async def install(
     package_names = [pkg.name for pkg in transaction.pyodide_packages] + [
         pkg.name for pkg in transaction.wheels
     ]
-    logger.info("Installing collected packages: " + ", ".join(package_names))
+
+    if package_names:
+        logger.info("Installing collected packages: " + ", ".join(package_names))
 
     wheel_promises = []
     # Install built-in packages
@@ -155,6 +157,8 @@ async def install(
     packages = [f"{pkg.name}-{pkg.version}" for pkg in transaction.pyodide_packages] + [
         f"{pkg.name}-{pkg.version}" for pkg in transaction.wheels
     ]
-    logger.info("Successfully installed " + ", ".join(packages))
+
+    if packages:
+        logger.info("Successfully installed " + ", ".join(packages))
 
     importlib.invalidate_caches()

--- a/micropip/_commands/install.py
+++ b/micropip/_commands/install.py
@@ -6,6 +6,7 @@ from packaging.markers import default_environment
 
 from .._compat import loadPackage, to_js
 from ..constants import FAQ_URLS
+from ..logging import setup_logging
 from ..transaction import Transaction
 
 
@@ -15,6 +16,8 @@ async def install(
     deps: bool = True,
     credentials: str | None = None,
     pre: bool = False,
+    *,
+    verbose: bool | int = False,
 ) -> None:
     """Install the given package and all of its dependencies.
 
@@ -83,7 +86,13 @@ async def install(
         If ``True``, include pre-release and development versions. By default,
         micropip only finds stable versions.
 
+    verbose :
+        Print more information about the process.
+        By default, micropip is silent. Setting ``verbose=True`` will print
+        mostly the same information as pip.
     """
+    logger = setup_logging(verbose)
+
     ctx = default_environment()
     if isinstance(requirements, str):
         requirements = [requirements]
@@ -107,6 +116,7 @@ async def install(
         deps=deps,
         pre=pre,
         fetch_kwargs=fetch_kwargs,
+        verbose=verbose,
     )
     await transaction.gather_requirements(requirements)
 
@@ -116,6 +126,11 @@ async def install(
             f"Can't find a pure Python 3 wheel for: {failed_requirements}\n"
             f"See: {FAQ_URLS['cant_find_wheel']}\n"
         )
+
+    package_names = [pkg.name for pkg in transaction.pyodide_packages] + [
+        pkg.name for pkg in transaction.wheels
+    ]
+    logger.info("Installing collected packages: " + ", ".join(package_names))
 
     wheel_promises = []
     # Install built-in packages
@@ -136,4 +151,10 @@ async def install(
         wheel_promises.append(wheel.install(wheel_base))
 
     await asyncio.gather(*wheel_promises)
+
+    packages = [f"{pkg.name}-{pkg.version}" for pkg in transaction.pyodide_packages] + [
+        f"{pkg.name}-{pkg.version}" for pkg in transaction.wheels
+    ]
+    logger.info("Successfully installed " + ", ".join(packages))
+
     importlib.invalidate_caches()

--- a/micropip/_commands/uninstall.py
+++ b/micropip/_commands/uninstall.py
@@ -1,6 +1,5 @@
 import importlib
 import importlib.metadata
-import warnings
 from importlib.metadata import Distribution
 
 from .._compat import loadedPackages
@@ -40,7 +39,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             dist = importlib.metadata.distribution(package)
             distributions.append(dist)
         except importlib.metadata.PackageNotFoundError:
-            warnings.warn(f"Skipping '{package}' as it is not installed.", stacklevel=1)
+            logger.warn(f"Skipping '{package}' as it is not installed.")
 
     for dist in distributions:
         # Note: this value needs to be retrieved before removing files, as
@@ -64,9 +63,8 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
                     # Since we don't support these, we can ignore them (except for data_files (TODO))
                     continue
 
-                warnings.warn(
+                logger.warn(
                     f"A file '{file}' listed in the metadata of '{dist.name}' does not exist.",
-                    stacklevel=1,
                 )
 
                 continue
@@ -81,19 +79,17 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             try:
                 directory.rmdir()
             except OSError:
-                warnings.warn(
+                logger.warn(
                     f"A directory '{directory}' is not empty after uninstallation of '{name}'. "
                     "This might cause problems when installing a new version of the package. ",
-                    stacklevel=1,
                 )
 
         if hasattr(loadedPackages, name):
             delattr(loadedPackages, name)
         else:
             # This should not happen, but just in case
-            warnings.warn(
+            logger.warn(
                 f"a package '{name}' was not found in loadedPackages.",
-                stacklevel=1,
             )
 
         logger.info(f"Successfully uninstalled {name}-{version}")

--- a/micropip/_commands/uninstall.py
+++ b/micropip/_commands/uninstall.py
@@ -64,7 +64,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
                     continue
 
                 logger.warn(
-                    f"A file '{file}' listed in the metadata of '{dist.name}' does not exist.",
+                    f"A file '{file}' listed in the metadata of '{name}' does not exist.",
                 )
 
                 continue

--- a/micropip/_commands/uninstall.py
+++ b/micropip/_commands/uninstall.py
@@ -39,7 +39,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             dist = importlib.metadata.distribution(package)
             distributions.append(dist)
         except importlib.metadata.PackageNotFoundError:
-            logger.warn(f"Skipping '{package}' as it is not installed.")
+            logger.warning(f"Skipping '{package}' as it is not installed.")
 
     for dist in distributions:
         # Note: this value needs to be retrieved before removing files, as
@@ -63,7 +63,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
                     # Since we don't support these, we can ignore them (except for data_files (TODO))
                     continue
 
-                logger.warn(
+                logger.warning(
                     f"A file '{file}' listed in the metadata of '{name}' does not exist.",
                 )
 
@@ -79,7 +79,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             try:
                 directory.rmdir()
             except OSError:
-                logger.warn(
+                logger.warning(
                     f"A directory '{directory}' is not empty after uninstallation of '{name}'. "
                     "This might cause problems when installing a new version of the package. ",
                 )
@@ -88,7 +88,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             delattr(loadedPackages, name)
         else:
             # This should not happen, but just in case
-            logger.warn(
+            logger.warning(
                 f"a package '{name}' was not found in loadedPackages.",
             )
 

--- a/micropip/_commands/uninstall.py
+++ b/micropip/_commands/uninstall.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.metadata
+import warnings
 from importlib.metadata import Distribution
 
 from .._compat import loadedPackages
@@ -39,7 +40,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             dist = importlib.metadata.distribution(package)
             distributions.append(dist)
         except importlib.metadata.PackageNotFoundError:
-            logger.warn(f"Skipping '{package}' as it is not installed.", stacklevel=1)
+            warnings.warn(f"Skipping '{package}' as it is not installed.", stacklevel=1)
 
     for dist in distributions:
         # Note: this value needs to be retrieved before removing files, as
@@ -48,7 +49,6 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
         version = dist.version
 
         logger.info(f"Found existing installation: {name} {version}")
-        logger.info(f"Uninstalling {name}-{version}")
 
         root = get_root(dist)
         files = get_files_in_distribution(dist)
@@ -64,7 +64,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
                     # Since we don't support these, we can ignore them (except for data_files (TODO))
                     continue
 
-                logger.warn(
+                warnings.warn(
                     f"A file '{file}' listed in the metadata of '{dist.name}' does not exist.",
                     stacklevel=1,
                 )
@@ -81,7 +81,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             try:
                 directory.rmdir()
             except OSError:
-                logger.warn(
+                warnings.warn(
                     f"A directory '{directory}' is not empty after uninstallation of '{name}'. "
                     "This might cause problems when installing a new version of the package. ",
                     stacklevel=1,
@@ -91,7 +91,7 @@ def uninstall(packages: str | list[str], *, verbose: bool | int = False) -> None
             delattr(loadedPackages, name)
         else:
             # This should not happen, but just in case
-            logger.warn(
+            warnings.warn(
                 f"a package '{name}' was not found in loadedPackages.",
                 stacklevel=1,
             )

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -47,9 +47,3 @@ def get_files_in_distribution(dist: Distribution) -> set[Path]:
     files_to_remove.update(metadata_files)
 
     return files_to_remove
-
-
-def log(message: str, verbose: bool = False):
-    # TODO: use logging instead of print
-    if verbose:
-        print(message)

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -47,3 +47,9 @@ def get_files_in_distribution(dist: Distribution) -> set[Path]:
     files_to_remove.update(metadata_files)
 
     return files_to_remove
+
+
+def log(message: str, verbose: bool = False):
+    # TODO: use logging instead of print
+    if verbose:
+        print(message)

--- a/micropip/logging.py
+++ b/micropip/logging.py
@@ -1,7 +1,8 @@
+import contextlib
 import logging
 import sys
-from typing import Generator, Any
-import contextlib
+from collections.abc import Generator
+from typing import Any
 
 _logger: logging.Logger | None = None
 _indentation: int = 0
@@ -70,8 +71,8 @@ class IndentingFormatter(logging.Formatter):
         formatted = "".join([prefix + line for line in formatted.splitlines(True)])
         return formatted
 
-def _set_formatter_once():
 
+def _set_formatter_once():
     global _logger
 
     if _logger is not None:
@@ -87,7 +88,6 @@ def _set_formatter_once():
 
 
 def setup_logging(verbosity: int | bool) -> logging.Logger:
-
     _set_formatter_once()
 
     if verbosity >= 2:

--- a/micropip/logging.py
+++ b/micropip/logging.py
@@ -1,0 +1,103 @@
+import logging
+import sys
+from typing import Generator, Any
+import contextlib
+
+_logger: logging.Logger | None = None
+_indentation: int = 0
+
+
+@contextlib.contextmanager
+def indent_log(num: int = 2) -> Generator[None, None, None]:
+    """
+    A context manager which will cause the log output to be indented for any
+    log messages emitted inside it.
+    """
+    global _indentation
+
+    _indentation += num
+    try:
+        yield
+    finally:
+        _indentation -= num
+
+
+# borrowed from pip._internal.utils.logging
+class IndentingFormatter(logging.Formatter):
+    default_time_format = "%Y-%m-%dT%H:%M:%S"
+
+    def __init__(
+        self,
+        *args: Any,
+        add_timestamp: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """
+        A logging.Formatter that obeys the indent_log() context manager.
+        :param add_timestamp: A bool indicating output lines should be prefixed
+            with their record's timestamp.
+        """
+        self.add_timestamp = add_timestamp
+        super().__init__(*args, **kwargs)
+
+    def get_message_start(self, formatted: str, levelno: int) -> str:
+        """
+        Return the start of the formatted log message (not counting the
+        prefix to add to each line).
+        """
+        if levelno < logging.WARNING:
+            return ""
+        if levelno < logging.ERROR:
+            return "WARNING: "
+
+        return "ERROR: "
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Calls the standard formatter, but will indent all of the log message
+        lines by our current indentation level.
+        """
+        global _indentation
+
+        formatted = super().format(record)
+        message_start = self.get_message_start(formatted, record.levelno)
+        formatted = message_start + formatted
+
+        prefix = ""
+        if self.add_timestamp:
+            prefix = f"{self.formatTime(record)} "
+        prefix += " " * _indentation
+        formatted = "".join([prefix + line for line in formatted.splitlines(True)])
+        return formatted
+
+def _set_formatter_once():
+
+    global _logger
+
+    if _logger is not None:
+        return
+
+    _logger = logging.getLogger(__name__)
+
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(logging.WARNING)
+    ch.setFormatter(IndentingFormatter())
+
+    _logger.addHandler(ch)
+
+
+def setup_logging(verbosity: int | bool) -> logging.Logger:
+
+    _set_formatter_once()
+
+    if verbosity >= 2:
+        level_number = logging.DEBUG
+    elif verbosity == 1:  # True == 1
+        level_number = logging.INFO
+    else:
+        level_number = logging.WARNING
+
+    assert _logger
+    _logger.setLevel(level_number)
+
+    return _logger

--- a/micropip/logging.py
+++ b/micropip/logging.py
@@ -81,7 +81,7 @@ def _set_formatter_once():
     _logger = logging.getLogger(__name__)
 
     ch = logging.StreamHandler(sys.stdout)
-    ch.setLevel(logging.WARNING)
+    ch.setLevel(logging.NOTSET)
     ch.setFormatter(IndentingFormatter())
 
     _logger.addHandler(ch)

--- a/micropip/logging.py
+++ b/micropip/logging.py
@@ -72,13 +72,13 @@ class IndentingFormatter(logging.Formatter):
         return formatted
 
 
-def _set_formatter_once():
+def _set_formatter_once() -> None:
     global _logger
 
     if _logger is not None:
         return
 
-    _logger = logging.getLogger(__name__)
+    _logger = logging.getLogger("micropip")
 
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.NOTSET)

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -338,7 +338,7 @@ class Transaction:
 
         satisfied, ver = self.check_version_satisfied(req)
         if satisfied:
-            logger.info(f"Requirement already satisfied: {req}{req.specifier} ({ver})")
+            logger.info(f"Requirement already satisfied: {req} ({ver})")
             return
 
         # If there's a Pyodide package that matches the version constraint, use

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -30,7 +30,7 @@ from .constants import FAQ_URLS
 from .externals.pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
 from .package import PackageMetadata
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("micropip")
 
 
 @dataclass

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -338,7 +338,7 @@ class Transaction:
 
         satisfied, ver = self.check_version_satisfied(req)
         if satisfied:
-            logger.info(f"Requirement already satisfied: {req} ({ver})")
+            logger.info(f"Requirement already satisfied: {req}{req.specifier} ({ver})")
             return
 
         # If there's a Pyodide package that matches the version constraint, use

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -379,6 +379,24 @@ class Transaction:
         *,
         specifier: str = "",
     ) -> None:
+        """
+        Download a wheel, and add its dependencies to the transaction.
+
+        Parameters
+        ----------
+        wheel
+            The wheel to add.
+
+        extras
+            Markers for optional dependencies.
+            For example, `micropip.install("pkg[test]")`
+            will pass `{"test"}` as the extras argument.
+
+        specifier
+            Requirement specifier, used only for logging.
+            For example, `micropip.install("pkg>=1.0.0,!=2.0.0")`
+            will pass `>=1.0.0,!=2.0.0` as the specifier argument.
+        """
         normalized_name = canonicalize_name(wheel.name)
         self.locked[normalized_name] = PackageMetadata(
             name=wheel.name,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from conftest import SNOWBALL_WHEEL, mock_fetch_cls
+from packaging.utils import parse_wheel_filename
 from pytest_pyodide import run_in_pyodide, spawn_web_server
 
 import micropip
@@ -360,3 +361,31 @@ def test_emfs(selenium_standalone_micropip):
             ]
 
         run_test(selenium_standalone_micropip, url, SNOWBALL_WHEEL)
+
+
+def test_logging(selenium_standalone_micropip):
+    # TODO: make a fixture for this, it's used in a few places
+    with spawn_web_server(Path(__file__).parent / "dist") as server:
+        server_hostname, server_port, _ = server
+        url = f"http://{server_hostname}:{server_port}/"
+        wheel_url = url + SNOWBALL_WHEEL
+        name, version, _, _ = parse_wheel_filename(SNOWBALL_WHEEL)
+
+        @run_in_pyodide(packages=["micropip"])
+        async def run_test(selenium, url, name, version):
+            import contextlib
+            import io
+
+            import micropip
+
+            with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                await micropip.install(url, verbose=True)
+
+                captured = buf.getvalue()
+
+                assert f"Collecting {name}" in captured
+                assert f"  Downloading {name}" in captured
+                assert f"Installing collected packages: {name}" in captured
+                assert f"Successfully installed {name}-{version}" in captured
+
+        run_test(selenium_standalone_micropip, wheel_url, name, version)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,5 @@
 import logging
 
-import pytest
-
 import micropip.logging as _logging
 
 
@@ -21,13 +19,3 @@ def test_verbosity():
     logger = _logging.setup_logging(verbosity=False)
 
     assert logger.level == logging.WARNING
-
-
-@pytest.mark.parametrize("indentation", [0, 2, 4])
-def test_indent_log(indentation, caplog):
-    logger = _logging.setup_logging(verbosity=1)
-
-    with _logging.indent_log(indentation):
-        logger.info("test")
-
-    print(caplog.record_tuples)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,8 @@
 import logging
 
-import micropip.logging as _logging
 import pytest
+
+import micropip.logging as _logging
 
 
 def test_verbosity():
@@ -23,12 +24,10 @@ def test_verbosity():
 
 
 @pytest.mark.parametrize("indentation", [0, 2, 4])
-def test_indent_log(caplog, indentation):
-    _logging.setup_logging(verbosity=1)
+def test_indent_log(indentation, caplog):
+    logger = _logging.setup_logging(verbosity=1)
 
-    logger = logging.getLogger("micropip")
-    with caplog.at_level(logging.INFO, logger="micropip"):
-        with _logging.indent_log(indentation):
-            logger.info("test")
-    
-    assert caplog.record_tuples == [("micropip", logging.INFO, " " * indentation + "test")]
+    with _logging.indent_log(indentation):
+        logger.info("test")
+
+    print(caplog.record_tuples)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,34 @@
+import logging
+
+import micropip.logging as _logging
+import pytest
+
+
+def test_verbosity():
+    logger = _logging.setup_logging(verbosity=1)
+
+    assert logger.level == logging.INFO
+
+    logger = _logging.setup_logging(verbosity=2)
+
+    assert logger.level == logging.DEBUG
+
+    logger = _logging.setup_logging(verbosity=True)
+
+    assert logger.level == logging.INFO
+
+    logger = _logging.setup_logging(verbosity=False)
+
+    assert logger.level == logging.WARNING
+
+
+@pytest.mark.parametrize("indentation", [0, 2, 4])
+def test_indent_log(caplog, indentation):
+    _logging.setup_logging(verbosity=1)
+
+    logger = logging.getLogger("micropip")
+    with caplog.at_level(logging.INFO, logger="micropip"):
+        with _logging.indent_log(indentation):
+            logger.info("test")
+    
+    assert caplog.record_tuples == [("micropip", logging.INFO, " " * indentation + "test")]

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -130,7 +130,7 @@ async def test_add_requirement_query_url(mock_importlib, wheel_base, monkeypatch
     pytest.importorskip("packaging")
     from micropip.transaction import Transaction
 
-    async def mock_add_wheel(self, wheel, extras):
+    async def mock_add_wheel(self, wheel, extras, *, specifier=""):
         self.mock_wheel = wheel
 
     monkeypatch.setattr(Transaction, "add_wheel", mock_add_wheel)


### PR DESCRIPTION
This adds `verbose` parameter to `micropip.install` and `micropip.uninstall`.

Setting verbose=True will print the installation/uninstallation process.

![image](https://user-images.githubusercontent.com/24893111/232032126-e30d9b37-1024-4fba-b649-fb78e0c058e8.png)

A known issue is that it does not show dependencies of packages in repodata.json (as it is handled by `loadPackage`)

![image](https://user-images.githubusercontent.com/24893111/232031895-7ffa1371-04d0-442a-96d6-c8dd953e0ed3.png)

- [x] changelog