### PR TITLE
Fixed broken link to FAQ

### DIFF
--- a/micropip/constants.py
+++ b/micropip/constants.py
@@ -1,3 +1,3 @@
 FAQ_URLS = {
-    "cant_find_wheel": "https://pyodide.org/en/stable/usage/faq.html#micropip-can-t-find-a-pure-python-wheel"
+    "cant_find_wheel": "https://pyodide.org/en/stable/usage/faq.html#why-can-t-micropip-find-a-pure-python-wheel-for-a-package"
 }


### PR DESCRIPTION
The link to the FAQ anchor has changed.

https://github.com/pyodide/pyodide/blob/1012a3fed9280b85ea633e25bc2999a21fe1be20/docs/usage/faq.md?plain=1#L320

https://pyodide.org/en/stable/usage/faq.html#why-can-t-micropip-find-a-pure-python-wheel-for-a-package