### PR TITLE
MAINT Store data in bytes not io.BytesIO

### DIFF
--- a/micropip/_compat_in_pyodide.py
+++ b/micropip/_compat_in_pyodide.py
@@ -25,7 +25,7 @@ async def fetch_bytes(url: str, kwargs: dict[str, str]) -> bytes:
         return Path(parsed_url.path).read_bytes()
     if parsed_url.scheme == "file":
         return (await loadBinaryFile(parsed_url.path)).to_bytes()
-    
+
     return await (await pyfetch(url, **kwargs)).bytes()
 
 

--- a/micropip/_compat_in_pyodide.py
+++ b/micropip/_compat_in_pyodide.py
@@ -1,5 +1,4 @@
-from io import BytesIO
-from typing import IO
+from pathlib import Path
 from urllib.parse import urlparse
 
 from pyodide._package_loader import get_dynlibs
@@ -20,15 +19,15 @@ except ImportError:
     # Otherwise, this is pytest test collection so let it go.
 
 
-async def fetch_bytes(url: str, kwargs: dict[str, str]) -> IO[bytes]:
+async def fetch_bytes(url: str, kwargs: dict[str, str]) -> bytes:
     parsed_url = urlparse(url)
     if parsed_url.scheme == "emfs":
-        return open(parsed_url.path, "rb")
+        result_bytes = Path(parsed_url.path).read_bytes()
     if parsed_url.scheme == "file":
         result_bytes = (await loadBinaryFile(parsed_url.path)).to_bytes()
     else:
         result_bytes = await (await pyfetch(url, **kwargs)).bytes()
-    return BytesIO(result_bytes)
+    return result_bytes
 
 
 async def fetch_string_and_headers(

--- a/micropip/_compat_in_pyodide.py
+++ b/micropip/_compat_in_pyodide.py
@@ -22,12 +22,11 @@ except ImportError:
 async def fetch_bytes(url: str, kwargs: dict[str, str]) -> bytes:
     parsed_url = urlparse(url)
     if parsed_url.scheme == "emfs":
-        result_bytes = Path(parsed_url.path).read_bytes()
-    elif parsed_url.scheme == "file":
-        result_bytes = (await loadBinaryFile(parsed_url.path)).to_bytes()
-    else:
-        result_bytes = await (await pyfetch(url, **kwargs)).bytes()
-    return result_bytes
+        return Path(parsed_url.path).read_bytes()
+    if parsed_url.scheme == "file":
+        return (await loadBinaryFile(parsed_url.path)).to_bytes()
+    
+    return await (await pyfetch(url, **kwargs)).bytes()
 
 
 async def fetch_string_and_headers(

--- a/micropip/_compat_in_pyodide.py
+++ b/micropip/_compat_in_pyodide.py
@@ -23,7 +23,7 @@ async def fetch_bytes(url: str, kwargs: dict[str, str]) -> bytes:
     parsed_url = urlparse(url)
     if parsed_url.scheme == "emfs":
         result_bytes = Path(parsed_url.path).read_bytes()
-    if parsed_url.scheme == "file":
+    elif parsed_url.scheme == "file":
         result_bytes = (await loadBinaryFile(parsed_url.path)).to_bytes()
     else:
         result_bytes = await (await pyfetch(url, **kwargs)).bytes()

--- a/micropip/_compat_not_in_pyodide.py
+++ b/micropip/_compat_not_in_pyodide.py
@@ -1,5 +1,4 @@
 import re
-from io import BytesIO
 from pathlib import Path
 from typing import IO, Any
 
@@ -20,9 +19,9 @@ def _fetch(url: str, kwargs: dict[str, Any]) -> addinfourl:
     return urlopen(Request(url, **kwargs))
 
 
-async def fetch_bytes(url: str, kwargs: dict[str, Any]) -> IO[bytes]:
+async def fetch_bytes(url: str, kwargs: dict[str, Any]) -> bytes:
     response = _fetch(url, kwargs=kwargs)
-    return BytesIO(response.read())
+    return response.read()
 
 
 async def fetch_string_and_headers(

--- a/micropip/_compat_not_in_pyodide.py
+++ b/micropip/_compat_not_in_pyodide.py
@@ -20,8 +20,7 @@ def _fetch(url: str, kwargs: dict[str, Any]) -> addinfourl:
 
 
 async def fetch_bytes(url: str, kwargs: dict[str, Any]) -> bytes:
-    response = _fetch(url, kwargs=kwargs)
-    return response.read()
+    return _fetch(url, kwargs=kwargs).read()
 
 
 async def fetch_string_and_headers(

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -5,7 +5,7 @@ import json
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, Any
+from typing import Any
 from urllib.parse import ParseResult, urlparse
 
 from packaging.requirements import Requirement
@@ -200,9 +200,7 @@ def _validate_sha256_checksum(data: bytes, expected: str | None = None) -> None:
 
     actual = _generate_package_hash(data)
     if actual != expected:
-        raise RuntimeError(
-            f"Invalid checksum: expected {expected}, got {actual}"
-        )
+        raise RuntimeError(f"Invalid checksum: expected {expected}, got {actual}")
 
 
 def _generate_package_hash(data: bytes) -> str:

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import io
 import json
 import zipfile
 from dataclasses import dataclass
@@ -39,7 +40,7 @@ class WheelInfo:
 
     # Fields below are only available after downloading the wheel, i.e. after calling `download()`.
 
-    _data: IO[bytes] | None = None  # Wheel file contents.
+    _data: bytes | None = None  # Wheel file contents.
     _metadata: Metadata | None = None  # Wheel metadata.
     _requires: list[Requirement] | None = None  # List of requirements.
 
@@ -109,7 +110,7 @@ class WheelInfo:
             raise RuntimeError(
                 "Micropip internal error: attempted to install wheel before downloading it?"
             )
-        self._validate()
+        _validate_sha256_checksum(self._data, self.sha256)
         self._extract(target)
         await self._load_libraries(target)
         self._set_installer()
@@ -119,7 +120,7 @@ class WheelInfo:
             return
 
         self._data = await self._fetch_bytes(fetch_kwargs)
-        with zipfile.ZipFile(self._data) as zf:
+        with zipfile.ZipFile(io.BytesIO(self._data)) as zf:
             metadata_path = wheel_dist_info_dir(zf, self.name) + "/" + Metadata.PKG_INFO
             self._metadata = Metadata(zipfile.Path(zf, metadata_path))
 
@@ -153,20 +154,9 @@ class WheelInfo:
                     "Check if the server is sending the correct 'Access-Control-Allow-Origin' header."
                 ) from e
 
-    def _validate(self):
-        if self.sha256 is None:
-            # No checksums available, e.g. because installing
-            # from a different location than PyPI.
-            return
-
-        assert self._data
-        sha256_actual = _generate_package_hash(self._data)
-        if sha256_actual != self.sha256:
-            raise ValueError("Contents don't match hash")
-
     def _extract(self, target: Path) -> None:
         assert self._data
-        with zipfile.ZipFile(self._data) as zf:
+        with zipfile.ZipFile(io.BytesIO(self._data)) as zf:
             zf.extractall(target)
             self._dist_info = target / wheel_dist_info_dir(zf, self.name)
 
@@ -198,16 +188,22 @@ class WheelInfo:
         TODO: integrate with pyodide's dynamic library loading mechanism.
         """
         assert self._data
-        dynlibs = get_dynlibs(self._data, ".whl", target)
+        dynlibs = get_dynlibs(io.BytesIO(self._data), ".whl", target)
         await asyncio.gather(*map(lambda dynlib: loadDynlib(dynlib, False), dynlibs))
 
 
-def _generate_package_hash(data: IO[bytes]) -> str:
-    """
-    Generate a SHA256 hash of the package data.
-    """
-    sha256_hash = hashlib.sha256()
-    data.seek(0)
-    while chunk := data.read(4096):
-        sha256_hash.update(chunk)
-    return sha256_hash.hexdigest()
+def _validate_sha256_checksum(data: bytes, expected: str | None = None) -> None:
+    if expected is None:
+        # No checksums available, e.g. because installing
+        # from a different location than PyPI.
+        return
+
+    actual = _generate_package_hash(data)
+    if actual != expected:
+        raise RuntimeError(
+            f"Invalid checksum: expected {expected}, got {actual}"
+        )
+
+
+def _generate_package_hash(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,7 +257,7 @@ class mock_fetch_cls:
 
         tmp.seek(0)
 
-        return tmp
+        return tmp.read()
 
 
 @pytest.fixture

--- a/tests/test_data/test_wheel_uninstall/pyproject.toml
+++ b/tests/test_data/test_wheel_uninstall/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "test_wheel_uninstall"
+name = "test-wheel-uninstall"
 description = "Test wheel uninstall"
 requires-python = ">=3.10"
 version = "1.0.0"

--- a/tests/test_data/test_wheel_uninstall/pyproject.toml
+++ b/tests/test_data/test_wheel_uninstall/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.10"
 version = "1.0.0"
 
 [tool.setuptools]
-packages = ["deep", "deep.deep", "shallow", "test_wheel_uninstall"]
+packages = ["deep", "deep.deep", "shallow", "test_wheel_uninstall", "deep.data"]
 py-modules = ["top_level"]
 
 [tool.setuptools.package-data]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -381,7 +381,7 @@ async def test_custom_index_urls(mock_package_index_json_api, monkeypatch):
     async def _mock_fetch_bytes(url, *args):
         nonlocal _wheel_url
         _wheel_url = url
-        return BytesIO(b"fake wheel")
+        return b"fake wheel"
 
     from micropip import wheelinfo
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -370,8 +370,6 @@ def test_logging(selenium_standalone_micropip):
 
 @pytest.mark.asyncio
 async def test_custom_index_urls(mock_package_index_json_api, monkeypatch):
-    from io import BytesIO
-
     mock_server_fake_package = mock_package_index_json_api(
         pkgs=["fake-pkg-micropip-test"]
     )

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -53,7 +53,12 @@ def test_basic(selenium_standalone_micropip, test_wheel_url):
         # 3. Check that the module is not available with micropip.list()
         assert pkg_name not in micropip.list()
 
-    run(selenium_standalone_micropip, TEST_PACKAGE_NAME, TEST_PACKAGE_NAME_NORMALIZED, test_wheel_url)
+    run(
+        selenium_standalone_micropip,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_NAME_NORMALIZED,
+        test_wheel_url,
+    )
 
 
 def test_files(selenium_standalone_micropip, test_wheel_url):
@@ -87,7 +92,12 @@ def test_files(selenium_standalone_micropip, test_wheel_url):
 
         assert not dist._path.is_dir(), f"{dist._path} still exists after removal"
 
-    run(selenium_standalone_micropip, TEST_PACKAGE_NAME, TEST_PACKAGE_NAME_NORMALIZED, test_wheel_url)
+    run(
+        selenium_standalone_micropip,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_NAME_NORMALIZED,
+        test_wheel_url,
+    )
 
 
 def test_install_again(selenium_standalone_micropip, test_wheel_url):
@@ -125,7 +135,12 @@ def test_install_again(selenium_standalone_micropip, test_wheel_url):
         assert pkg_name_normalized in micropip.list()
         __import__(pkg_name)
 
-    run(selenium_standalone_micropip, TEST_PACKAGE_NAME, TEST_PACKAGE_NAME_NORMALIZED, test_wheel_url)
+    run(
+        selenium_standalone_micropip,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_NAME_NORMALIZED,
+        test_wheel_url,
+    )
 
 
 def test_warning_not_installed(selenium_standalone_micropip):
@@ -185,7 +200,12 @@ def test_warning_file_removed(selenium_standalone_micropip, test_wheel_url):
             assert "does not exist" in logs[-1]
             assert "does not exist" in logs[-2]
 
-    run(selenium_standalone_micropip, TEST_PACKAGE_NAME, TEST_PACKAGE_NAME_NORMALIZED, test_wheel_url)
+    run(
+        selenium_standalone_micropip,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_NAME_NORMALIZED,
+        test_wheel_url,
+    )
 
 
 def test_warning_remaining_file(selenium_standalone_micropip, test_wheel_url):
@@ -215,7 +235,12 @@ def test_warning_remaining_file(selenium_standalone_micropip, test_wheel_url):
             assert len(logs) == 1
             assert "is not empty after uninstallation" in logs[0]
 
-    run(selenium_standalone_micropip, TEST_PACKAGE_NAME, TEST_PACKAGE_NAME_NORMALIZED, test_wheel_url)
+    run(
+        selenium_standalone_micropip,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_NAME_NORMALIZED,
+        test_wheel_url,
+    )
 
 
 def test_pyodide_repodata(selenium_standalone_micropip):

--- a/tests/test_wheelinfo.py
+++ b/tests/test_wheelinfo.py
@@ -1,5 +1,3 @@
-from io import BytesIO
-
 import pytest
 from conftest import PYTEST_WHEEL, TEST_WHEEL_DIR
 

--- a/tests/test_wheelinfo.py
+++ b/tests/test_wheelinfo.py
@@ -13,7 +13,7 @@ def dummy_wheel():
 
 @pytest.fixture
 def dummy_wheel_content():
-    yield BytesIO((TEST_WHEEL_DIR / PYTEST_WHEEL).read_bytes())
+    yield (TEST_WHEEL_DIR / PYTEST_WHEEL).read_bytes()
 
 
 @pytest.fixture
@@ -54,25 +54,6 @@ def test_from_package_index():
     assert wheel.filename == filename
     assert wheel.size == size
     assert wheel.sha256 == sha256
-
-
-def test_validate(dummy_wheel):
-    import hashlib
-
-    dummy_wheel.sha256 = None
-    dummy_wheel._data = BytesIO(b"dummy-data")
-
-    # Should succeed when sha256 is None
-    dummy_wheel._validate()
-
-    # Should fail when checksum is different
-    dummy_wheel.sha256 = "dummy-sha256"
-    with pytest.raises(ValueError, match="Contents don't match hash"):
-        dummy_wheel._validate()
-
-    # Should succeed when checksum is the same
-    dummy_wheel.sha256 = hashlib.sha256(b"dummy-data").hexdigest()
-    dummy_wheel._validate()
 
 
 def test_extract(dummy_wheel, dummy_wheel_content, tmp_path):


### PR DESCRIPTION
This is a split off of #90.

This PR changes how wheel data is stored in `WheelInfo` class during the package installation: instead of converting the downloaded wheel data to `io.BytesIO` and storing it, store it as `bytes` and convert it to `io.BytesIO` when we need to pass it to other methods that accepts `io.BytesIO` object.

No functional change is intended, just to avoid the mistake of having to do a seek(0) after reading the data.

There seems a slight overhead of converting bytes to io.BytesIO, but I think it is not critical.

<details>
  <summary>Benchmark</summary>

```python
import io
import timeit

num_iterations = 10000
bytes_size = 100_000
bytes_obj = b'0' * bytes_size

def bench_bytes():
    for i in range(num_iterations):
        io_obj = io.BytesIO(bytes_obj)
        io_obj.read()

def bench_bytesio():
    io_obj = io.BytesIO(bytes_obj)
    for i in range(num_iterations):
        io_obj.seek(0)
        io_obj.read()

print('Benchmarking using a single BytesIO object and seek()...')
print(timeit.timeit(bench_bytesio, number=1))
print('Benchmarking converting bytes to io.BytesIO multiple times...')
print(timeit.timeit(bench_bytes, number=1))
```

```
Benchmarking using a single BytesIO object and seek()...
0.0006137999998827581
Benchmarking converting bytes to io.BytesIO multiple times...
0.001084399999854213
```

</details>