### PR TITLE
Port `list` and `mock_package` into PackageManager

### DIFF
--- a/micropip/_commands/list.py
+++ b/micropip/_commands/list.py
@@ -1,58 +1,8 @@
-import importlib.metadata
+from micropip.list import list_installed_packages
 
-from .._compat import REPODATA_PACKAGES, loadedPackages
-from ..package import PackageDict, PackageMetadata
+from .._compat import REPODATA_PACKAGES
+from ..package import PackageDict
 
 
 def _list() -> PackageDict:
-    """Get the dictionary of installed packages.
-
-    Returns
-    -------
-    ``PackageDict``
-        A dictionary of installed packages.
-
-        >>> import micropip
-        >>> await micropip.install('regex') # doctest: +SKIP
-        >>> package_list = micropip.list()
-        >>> print(package_list) # doctest: +SKIP
-        Name              | Version  | Source
-        ----------------- | -------- | -------
-        regex             | 2021.7.6 | pyodide
-        >>> "regex" in package_list # doctest: +SKIP
-        True
-    """
-
-    # Add packages that are loaded through pyodide.loadPackage
-    packages = PackageDict()
-    for dist in importlib.metadata.distributions():
-        name = dist.name
-        version = dist.version
-        source = dist.read_text("PYODIDE_SOURCE")
-        if source is None:
-            # source is None if PYODIDE_SOURCE does not exist. In this case the
-            # wheel was installed manually, not via `pyodide.loadPackage` or
-            # `micropip`.
-            continue
-        packages[name] = PackageMetadata(
-            name=name,
-            version=version,
-            source=source,
-        )
-
-    for name, pkg_source in loadedPackages.to_py().items():
-        if name in packages:
-            continue
-
-        if name in REPODATA_PACKAGES:
-            version = REPODATA_PACKAGES[name]["version"]
-            source_ = "pyodide"
-            if pkg_source != "default channel":
-                # Pyodide package loaded from a custom URL
-                source_ = pkg_source
-        else:
-            # TODO: calculate version from wheel metadata
-            version = "unknown"
-            source_ = pkg_source
-        packages[name] = PackageMetadata(name=name, version=version, source=source_)
-    return packages
+    return list_installed_packages(REPODATA_PACKAGES)

--- a/micropip/_commands/list.py
+++ b/micropip/_commands/list.py
@@ -1,6 +1,5 @@
-from micropip.list import list_installed_packages
-
 from .._compat import REPODATA_PACKAGES
+from ..list import list_installed_packages
 from ..package import PackageDict
 
 

--- a/micropip/list.py
+++ b/micropip/list.py
@@ -1,0 +1,61 @@
+import importlib.metadata
+from typing import Any
+
+from ._compat import loadedPackages
+from .package import PackageDict, PackageMetadata
+
+
+def list_installed_packages(
+    lockfile_packages: dict[str, dict[str, Any]]
+) -> PackageDict:
+    """Get the dictionary of installed packages.
+
+    Returns
+    -------
+    ``PackageDict``
+        A dictionary of installed packages.
+
+        >>> import micropip
+        >>> await micropip.install('regex') # doctest: +SKIP
+        >>> package_list = micropip.list()
+        >>> print(package_list) # doctest: +SKIP
+        Name              | Version  | Source
+        ----------------- | -------- | -------
+        regex             | 2021.7.6 | pyodide
+        >>> "regex" in package_list # doctest: +SKIP
+        True
+    """
+
+    # Add packages that are loaded through pyodide.loadPackage
+    packages = PackageDict()
+    for dist in importlib.metadata.distributions():
+        name = dist.name
+        version = dist.version
+        source = dist.read_text("PYODIDE_SOURCE")
+        if source is None:
+            # source is None if PYODIDE_SOURCE does not exist. In this case the
+            # wheel was installed manually, not via `pyodide.loadPackage` or
+            # `micropip`.
+            continue
+        packages[name] = PackageMetadata(
+            name=name,
+            version=version,
+            source=source,
+        )
+
+    for name, pkg_source in loadedPackages.to_py().items():
+        if name in packages:
+            continue
+
+        if name in lockfile_packages:
+            version = lockfile_packages[name]["version"]
+            source_ = "pyodide"
+            if pkg_source != "default channel":
+                # Pyodide package loaded from a custom URL
+                source_ = pkg_source
+        else:
+            # TODO: calculate version from wheel metadata
+            version = "unknown"
+            source_ = pkg_source
+        packages[name] = PackageMetadata(name=name, version=version, source=source_)
+    return packages

--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -4,6 +4,7 @@ from typing import (  # noqa: UP035 List import is necessary due to the `list` m
 )
 
 from micropip import package_index
+from micropip._commands import mock_package
 from micropip.freeze import freeze_lockfile
 from micropip.list import list_installed_packages
 from micropip.package import PackageDict
@@ -37,14 +38,23 @@ class PackageManager:
     def freeze(self) -> str:
         return freeze_lockfile(self.repodata_packages, self.repodata_info)
 
-    def add_mock_package(self):
-        raise NotImplementedError()
+    def add_mock_package(
+        self,
+        name: str,
+        version: str,
+        *,
+        modules: dict[str, str | None] | None = None,
+        persistent: bool = False,
+    ):
+        return mock_package.add_mock_package(
+            name, version, modules=modules, persistent=persistent
+        )
 
     def list_mock_packages(self):
-        raise NotImplementedError()
+        return mock_package.list_mock_packages()
 
-    def remove_mock_package(self):
-        raise NotImplementedError()
+    def remove_mock_package(self, name: str):
+        return mock_package.remove_mock_package(name)
 
     def uninstall(self):
         raise NotImplementedError()

--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -5,6 +5,8 @@ from typing import (  # noqa: UP035 List import is necessary due to the `list` m
 
 from micropip import package_index
 from micropip.freeze import freeze_lockfile
+from micropip.list import list_installed_packages
+from micropip.package import PackageDict
 
 
 class PackageManager:
@@ -29,8 +31,8 @@ class PackageManager:
     def install(self):
         raise NotImplementedError()
 
-    def list(self):
-        raise NotImplementedError()
+    def list(self) -> PackageDict:
+        return list_installed_packages(self.repodata_packages)
 
     def freeze(self) -> str:
         return freeze_lockfile(self.repodata_packages, self.repodata_info)

--- a/tests/test_package_manager.py
+++ b/tests/test_package_manager.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 import micropip.package_index as package_index
 from micropip.package_manager import PackageManager
 
@@ -57,3 +59,12 @@ def test_freeze():
         "info": test_repodata_info,
         "packages": test_repodata_packages,
     }
+
+
+@pytest.mark.skip(reason="Not implemented")
+def test_list():
+    manager = get_test_package_manager()
+
+    _package_dict = manager.list()
+
+    # TODO: implement test after implementing manager.install()


### PR DESCRIPTION
- ported `list` into `PackageManager`, and moved the implementation of `list` to a new file under `micropip/list.py`.
- ported commands listed in `micropip/_commands/mock_package.py`.

