### PR TITLE
Improve alternative index handling.

### DIFF
--- a/micropip/_commands/install.py
+++ b/micropip/_commands/install.py
@@ -11,7 +11,7 @@ async def install(
     pre: bool = False,
     index_urls: list[str] | str | None = None,
     *,
-    verbose: bool | int = False,
+    verbose: bool | int | None = None,
 ) -> None:
     if index_urls is None:
         index_urls = package_index.INDEX_URLS[:]

--- a/micropip/install.py
+++ b/micropip/install.py
@@ -19,7 +19,7 @@ async def install(
     pre: bool = False,
     index_urls: list[str] | str | None = None,
     *,
-    verbose: bool | int = False,
+    verbose: bool | int | None = None,
 ) -> None:
     """Install the given package and all of its dependencies.
 

--- a/micropip/logging.py
+++ b/micropip/logging.py
@@ -87,17 +87,15 @@ def _set_formatter_once() -> None:
     _logger.addHandler(ch)
 
 
-def setup_logging(verbosity: int | bool) -> logging.Logger:
+def setup_logging(verbosity: int | bool | None) -> logging.Logger:
     _set_formatter_once()
-
-    if verbosity >= 2:
-        level_number = logging.DEBUG
-    elif verbosity == 1:  # True == 1
-        level_number = logging.INFO
-    else:
-        level_number = logging.WARNING
-
     assert _logger
-    _logger.setLevel(level_number)
-
+    if verbosity is not None:
+        if verbosity >= 2:
+            level_number = logging.DEBUG
+        elif verbosity == 1:  # True == 1
+            level_number = logging.INFO
+        else:
+            level_number = logging.WARNING
+        _logger.setLevel(level_number)
     return _logger

--- a/micropip/package_index.py
+++ b/micropip/package_index.py
@@ -322,7 +322,7 @@ async def query_package(
         try:
             metadata, headers = await fetch_string_and_headers(url, _fetch_kwargs)
         except OSError as e:
-            # Pypi does not currently set cors on 404, we we can't know
+            # PyPI does not currently set cors on 404, we can't know
             # whether this is a real OS error or a 404
             logger.debug("Error fetching %r, skipping. Error was %r", url, e)
             continue

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -14,7 +14,7 @@ from ._compat import REPODATA_PACKAGES
 from ._utils import best_compatible_tag_index, check_compatible
 from .constants import FAQ_URLS
 from .package import PackageMetadata
-from .package_index import ProjectInfo
+from .package_index import IndexMetadataFetchError, ProjectInfo
 from .wheelinfo import WheelInfo
 
 logger = logging.getLogger("micropip")
@@ -152,7 +152,7 @@ class Transaction:
             else:
                 try:
                     await self._add_requirement_from_package_index(req)
-                except WheelNotFoundError:
+                except (WheelNotFoundError, IndexMetadataFetchError):
                     # If the requirement is not found in package index,
                     # we still have a chance to find it from pyodide lockfile.
                     if self._add_requirement_from_pyodide_lock(req):

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -162,7 +162,7 @@ class Transaction:
                         )
                     else:
                         raise
-        except ValueError:
+        except (WheelNotFoundError, IndexMetadataFetchError):
             self.failed.append(req)
             if not self.keep_going:
                 raise


### PR DESCRIPTION
This improve the handling of indexes and error messages.

Before this PR all errors reaching an index would be ValueError, thus not finding a wheel was the same as the index page having a non-handled content type, or even failing to parse the html because of a typo.

This made it hard to debug, or even realize that an index url was wrong, or that the pages served by the index were incorrect.

I thus introduce 3 New Errors that do not inherit from `ValueError`:
 - IndexMetadataFetchError
 - UnsupportedParserContentTypeError
 - WheelNotFoundError

The first two of which trigger real error, as they likely suggest a problem with the index or the user config, and should not be ignored.

In addition the `verbose=` option was unconditionally setting the log level. I think this is improper as if the logging level is set somewhere else (to DEBUG, or something else), then it is overwritten.

- This then adds the option to pass `verbose=None`, (and make it the default), in which case it will not change the default.

python -m http.server will serve ContentType with `; charset=utf-8`, which is not recognized.

- This now handle the case where the index ContentType header contains parameters for example `; charset=utf-8`, by discarding everything after the semicolon `;`; this is not proper parsing, but should be sufficient here.

 - I found that more debug logging would be useful and added a number of debug logs calls

With this I appear to get proper error message and debug statements when trying to work on the Cors proxy.

Should close #123, and #121, and help with pyodide/pyodide#4898