### PR TITLE
BUG: fetch_string_and_headers compat: raise in and out of pyodide

### DIFF
--- a/micropip/_compat/__init__.py
+++ b/micropip/_compat/__init__.py
@@ -34,6 +34,8 @@ get_dynlibs = compatibility_layer.get_dynlibs
 
 to_js = compatibility_layer.to_js
 
+HttpStatusError = compatibility_layer.HttpStatusError
+
 
 __all__ = [
     "REPODATA_INFO",
@@ -45,4 +47,5 @@ __all__ = [
     "loadPackage",
     "get_dynlibs",
     "to_js",
+    "HttpStatusError",
 ]

--- a/micropip/_compat/_compat_in_pyodide.py
+++ b/micropip/_compat/_compat_in_pyodide.py
@@ -5,21 +5,9 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     pass
 
-import pyodide
-from packaging.version import parse
 from pyodide._package_loader import get_dynlibs
 from pyodide.ffi import IN_BROWSER, to_js
-
-if parse(pyodide.__version__) > parse("0.27"):
-    from pyodide.http import HttpStatusError, pyfetch
-else:
-
-    class HttpStatusError(Exception):  # type: ignore [no-redef]
-        """we just want this to be defined, it is never going to be raised"""
-
-        pass
-
-    from pyodide.http import pyfetch
+from pyodide.http import HttpStatusError, pyfetch
 
 from .compatibility_layer import CompatibilityLayer
 

--- a/micropip/_compat/compatibility_layer.py
+++ b/micropip/_compat/compatibility_layer.py
@@ -13,6 +13,14 @@ class CompatibilityLayer(ABC):
     All of the following methods / properties must be implemented for use both inside and outside of pyodide.
     """
 
+    class HttpStatusError(ABC, Exception):
+        status_code: int
+        message: str
+
+        @abstractmethod
+        def __init__(self, status_code: int, message: str):
+            pass
+
     class loadedPackages(ABC):
         @staticmethod
         @abstractmethod

--- a/micropip/package_index.py
+++ b/micropip/package_index.py
@@ -280,23 +280,6 @@ async def query_package(
             if e.status_code == 404:
                 continue
             raise
-        except OSError:
-            # temporary pyodide compatibility.
-            # pypi now set proper CORS on 404 (https://github.com/pypi/warehouse/pull/16339),
-            # but stable pyodide (<0.27) does not yet have proper HttpStatusError exception
-            # so when: on pyodide and 0.26.x we ignore OSError. Once we drop support for 0.26
-            # all this OSError except clause should just be gone.
-            try:
-                import pyodide
-                from packaging.version import parse
-
-                if parse(pyodide.__version__) > parse("0.27"):
-                    # reraise on more recent pyodide.
-                    raise
-                continue
-            except ImportError:
-                # not in pyodide.
-                raise
 
         content_type = headers.get("content-type", "").lower()
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,6 +340,7 @@ def mock_fetch(monkeypatch, mock_importlib):
 def _mock_package_index_gen(
     httpserver,
     pkgs=("black", "pytest", "numpy", "pytz", "snowballstemmer"),
+    pkgs_not_found=(),
     content_type="application/json",
     suffix="_json.json.gz",
 ):
@@ -354,6 +355,10 @@ def _mock_package_index_gen(
             data,
             content_type=content_type,
             headers={"Access-Control-Allow-Origin": "*"},
+        )
+    for pkg in pkgs_not_found:
+        httpserver.expect_request(f"/{base}/{pkg}/").respond_with_data(
+            "Not found", status=404, content_type="text/plain"
         )
 
     index_url = httpserver.url_for(base)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -19,12 +19,7 @@ def test_404(selenium_standalone_micropip, httpserver, request):
 
         from micropip._compat import HttpStatusError, fetch_string_and_headers
 
-        if parse(pyodide.__version__) > parse("0.27"):
-            ExpectedErrorClass = HttpStatusError
-        else:
-            ExpectedErrorClass = OSError
-
-        with pytest.raises(ExpectedErrorClass):
+        with pytest.raises(HttpStatusError):
             await fetch_string_and_headers(url, {})
 
     httpserver.expect_request("/404").respond_with_data(

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -13,9 +13,7 @@ def test_404(selenium_standalone_micropip, httpserver, request):
 
     @run_in_pyodide(packages=["micropip", "packaging"])
     async def _inner_test_404_raise(selenium, url):
-        import pyodide
         import pytest
-        from packaging.version import parse
 
         from micropip._compat import HttpStatusError, fetch_string_and_headers
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,37 @@
+"""
+test that function in compati behave the same
+
+"""
+
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+
+@pytest.mark.driver_timeout(10)
+def test_404(selenium_standalone_micropip, httpserver, request):
+    selenium_standalone_micropip.set_script_timeout(11)
+
+    @run_in_pyodide(packages=["micropip", "packaging"])
+    async def _inner_test_404_raise(selenium, url):
+        import pyodide
+        import pytest
+        from packaging.version import parse
+
+        from micropip._compat import HttpStatusError, fetch_string_and_headers
+
+        if parse(pyodide.__version__) > parse("0.27"):
+            ExpectedErrorClass = HttpStatusError
+        else:
+            ExpectedErrorClass = OSError
+
+        with pytest.raises(ExpectedErrorClass):
+            await fetch_string_and_headers(url, {})
+
+    httpserver.expect_request("/404").respond_with_data(
+        "Not found",
+        status=404,
+        content_type="text/plain",
+        headers={"Access-Control-Allow-Origin": "*"},
+    )
+    url_404 = httpserver.url_for("/404")
+    _inner_test_404_raise(selenium_standalone_micropip, url_404)

--- a/tests/test_package_index.py
+++ b/tests/test_package_index.py
@@ -135,8 +135,8 @@ def test_contain_placeholder():
 )
 async def test_query_package(mock_fixture, pkg1, pkg2, request):
     gen_mock_server = request.getfixturevalue(mock_fixture)
-    pkg1_index_url = gen_mock_server(pkgs=[pkg1])
-    pkg2_index_url = gen_mock_server(pkgs=[pkg2])
+    pkg1_index_url = gen_mock_server(pkgs=[pkg1], pkgs_not_found=[pkg2])
+    pkg2_index_url = gen_mock_server(pkgs=[pkg2], pkgs_not_found=[pkg1])
 
     for _index_urls in (
         pkg1_index_url,


### PR DESCRIPTION
Currently only the not_in_pyodide will raise on non-success, because this is the default behavior of urllib, the in_pyodide will not, so I added a raise_for_status.

It is better to raise, as otherwise the package parser will potentially get proper URL and not manage to parse it, and decide there is no wheels, while we actually just got an error (404, or maybe 500).

In addition wraps both case in a custom local HttpStatusError, so that we can actually catch these errors in the right places when we encounter them.

I think we could define HttpStatusError on the ABC and not make it an ABC itself, but it small enough that I think duplication is ok.