### PR TITLE
Bump Pyodide on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        pyodide-version: [0.24.1, 0.25.0]
+        pyodide-version: ['0.24.1', '0.25.0', '0.26.2', '0.27.0a2']
         test-config: [
           {runner: selenium, runtime: chrome, runtime-version: latest },
         ]


### PR DESCRIPTION
Also change to explicitely use strings.

I'm guessing this should be bumped, maybe there is an automatic way to do latest ? Also not sure if you want to test on alphas, but I guess it's always useful to catch bugs.