### PR TITLE
Maint: Show test duration and limit to 15 failures.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,9 @@ jobs:
         run: |
           pytest -v \
             --cov=micropip \
+            --durations=10 \
             --dist-dir=./dist/ \
+            --maxfail=15 \
             --runner=${{ matrix.test-config.runner }} \
             --rt ${{ matrix.test-config.runtime }}
 


### PR DESCRIPTION
I don't think it is worth contiuing testing if there is more than 15 failures.

Also show the 10 slowest test, I'm hopping that will give us insight into how to make testing faster.