### PR TITLE
More debug logging

### DIFF
--- a/micropip/install.py
+++ b/micropip/install.py
@@ -154,6 +154,11 @@ async def install(
             pkg.name for pkg in transaction.wheels
         ]
 
+        logger.debug(
+            "Installing packages %r and wheels %r ",
+            transaction.pyodide_packages,
+            transaction.wheels,
+        )
         if package_names:
             logger.info("Installing collected packages: %s", ", ".join(package_names))
 

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -146,6 +146,7 @@ class Transaction:
         try:
             if self.search_pyodide_lock_first:
                 if self._add_requirement_from_pyodide_lock(req):
+                    logger.debug("Transaction: package found in lock file: %r", req)
                     return
 
                 await self._add_requirement_from_package_index(req)
@@ -153,9 +154,18 @@ class Transaction:
                 try:
                     await self._add_requirement_from_package_index(req)
                 except ValueError:
+                    logger.debug(
+                        "Transaction: package %r not found in index, will search lock file",
+                        req,
+                    )
+
                     # If the requirement is not found in package index,
                     # we still have a chance to find it from pyodide lockfile.
                     if not self._add_requirement_from_pyodide_lock(req):
+                        logger.debug(
+                            "Transaction: package %r not found in lock file", req
+                        )
+
                         raise
         except ValueError:
             self.failed.append(req)
@@ -187,7 +197,11 @@ class Transaction:
             req.name, self.fetch_kwargs, index_urls=self.index_urls
         )
 
+        logger.debug("Transaction: got metadata %r for requirement %r", metadata, req)
+
         wheel = find_wheel(metadata, req)
+
+        logger.debug("Transaction: Selected wheel: %r", wheel)
 
         # Maybe while we were downloading pypi_json some other branch
         # installed the wheel?


### PR DESCRIPTION
Basically still trying to make the proxy works, but so many errors are swallowed because everything that triggers a ValueError is just ignore. So add a bunch of debug to at least be able to debug.

    async def add_requirement_inner(
        self,
        req: Requirement,
    ) -> None:
        ....
        try:
            if self.search_pyodide_lock_first:
                ...
            else:
                try:
                    await self._add_requirement_from_package_index(req)
                except ValueError:
                    # basically this swallow things it should not, like
                    improper content type and likely a bunch of other.

This is where many ValueError are swallowed, I will send more changes to
change various error types.