### PR TITLE
Differenctiate `ValueError`s

### DIFF
--- a/micropip/errors.py
+++ b/micropip/errors.py
@@ -1,0 +1,24 @@
+"""
+A module to define micropip custom Exceptions.
+"""
+
+
+class UnsupportedContentTypeError(Exception):
+    """raise when selecting a parser for current index
+
+    This is raise if the current content type is not recognized.
+    """
+
+
+class NoCompatibleWheelError(Exception):
+    """
+    This is raised when a package is found but have no wheel compatible with
+    current pyodide.
+    """
+
+
+class PackageNotFoundOnAnyIndexError(Exception):
+    """
+    This is raised if current package was not found on any of the currently
+    listed index.
+    """

--- a/micropip/package_index.py
+++ b/micropip/package_index.py
@@ -13,6 +13,7 @@ from packaging.version import InvalidVersion, Version
 
 from ._compat import HttpStatusError, fetch_string_and_headers
 from ._utils import is_package_compatible, parse_version
+from .errors import PackageNotFoundOnAnyIndexError, UnsupportedContentTypeError
 from .externals.mousebender.simple import from_project_details_html
 from .wheelinfo import WheelInfo
 
@@ -218,10 +219,6 @@ def _contain_placeholder(url: str, placeholder: str = "package_name") -> bool:
     return placeholder in fields
 
 
-class UnsupportedContentTypeError(Exception):
-    pass
-
-
 def _select_parser(content_type: str, pkgname: str) -> Callable[[str], ProjectInfo]:
     """
     Select the function to parse the response based on the content type.
@@ -241,10 +238,6 @@ def _select_parser(content_type: str, pkgname: str) -> Callable[[str], ProjectIn
             raise UnsupportedContentTypeError(
                 f"Unsupported content type: {content_type}"
             )
-
-
-class NoValidIndexForPackageError(Exception):
-    pass
 
 
 async def query_package(
@@ -309,7 +302,7 @@ async def query_package(
         parser = _select_parser(content_type, name)
         return parser(metadata)
     else:
-        raise NoValidIndexForPackageError(
+        raise PackageNotFoundOnAnyIndexError(
             f"Can't fetch metadata for {name!r}. "
             "Please make sure you have entered a correct package name "
             "and correctly specified index_urls (if you changed them)."


### PR DESCRIPTION
ValueErrors are a bit too generic, and by raising/catching them we loose a potential useful information; For example an invalid content type for the index, is dealt as the same way than a missing wheel.

This introduces new exceptions for various cases, ant stop catching the now UnsupportedContentTypeError, as I believe it should be a hard error as we are likely having either an error with the index software, or a user configuraition error.

See also beginning of discussion in #142

-- 

Opening as draft, I'm expecting the tests to fails