### PR TITLE
Do not print fill WheelInfo in debug.

### DIFF
--- a/micropip/install.py
+++ b/micropip/install.py
@@ -157,7 +157,7 @@ async def install(
         logger.debug(
             "Installing packages %r and wheels %r ",
             transaction.pyodide_packages,
-            transaction.wheels,
+            [w.filename for w in transaction.wheels],
         )
         if package_names:
             logger.info("Installing collected packages: %s", ", ".join(package_names))

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -2,7 +2,7 @@ import hashlib
 import io
 import json
 import zipfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import ParseResult, urlparse
@@ -46,7 +46,7 @@ class WheelInfo:
 
     # Fields below are only available after downloading the wheel, i.e. after calling `download()`.
 
-    _data: bytes | None = None  # Wheel file contents.
+    _data: bytes | None = field(default=None, repr=False)  # Wheel file contents.
     _metadata: Metadata | None = None  # Wheel metadata.
     _requires: list[Requirement] | None = None  # List of requirements.
 


### PR DESCRIPTION
And also do not add `_data` to the WheelInfo REPR.

Trying to print the full wheelinfo (with all the binary data), will hang the console it's way to much info.

So exclude the data from the repr, and only print the filename in debug login installing.