### PR TITLE
TST Test micropip.freeze() with pyodide-lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ test = [
   "pytest-cov",
   "pytest<8.0.0",
   "build==0.7.0",
+  "pyodide-lock==v0.1.0a8",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ class WheelCatalog:
         _path: Path
 
         name: str
+        version: str
         filename: str
         top_level: str
         url: str
@@ -128,14 +129,14 @@ class WheelCatalog:
         return self._httpserver.url_for(f"/{path.name}")
 
     def add_wheel(self, path: Path, replace: bool = True):
-        name = parse_wheel_filename(path.name)[0]
+        name, version = parse_wheel_filename(path.name)[0:1]
         url = self._register_handler(path)
 
         if name in self._wheels and not replace:
             return
 
         self._wheels[name] = self.Wheel(
-            path, name, path.name, name.replace("-", "_"), url
+            path, name, str(version), path.name, name.replace("-", "_"), url
         )
 
     def get(self, name: str) -> Wheel:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,7 @@ class WheelCatalog:
         return self._httpserver.url_for(f"/{path.name}")
 
     def add_wheel(self, path: Path, replace: bool = True):
-        name, version = parse_wheel_filename(path.name)[0:1]
+        name, version = parse_wheel_filename(path.name)[0:2]
         url = self._register_handler(path)
 
         if name in self._wheels and not replace:

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -84,11 +84,11 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog, tmp
         f.write(lockfile_content)
 
     lockfile = PyodideLockSpec.from_json(lockfile_path)
-    assert lockfile.packages["snowballstemmer"]["file_name"] == url
-    assert lockfile.packages["snowballstemmer"]["name"] == "snowballstemmer"
-    assert lockfile.packages["snowballstemmer"]["depends"] == []
-    assert lockfile.packages["snowballstemmer"]["imports"] == ["snowball"]
-    assert lockfile.packages["snowballstemmer"]["install_dir"] == "site"
-    assert not lockfile.packages["snowballstemmer"]["unvendored_tests"]
-    assert lockfile.packages["snowballstemmer"]["version"] == snowball_wheel.version
+    assert lockfile.packages["snowballstemmer"].file_name == url
+    assert lockfile.packages["snowballstemmer"].name == "snowballstemmer"
+    assert lockfile.packages["snowballstemmer"].depends == []
+    assert lockfile.packages["snowballstemmer"].imports == ["snowball"]
+    assert lockfile.packages["snowballstemmer"].install_dir == "site"
+    assert not lockfile.packages["snowballstemmer"].unvendored_tests
+    assert lockfile.packages["snowballstemmer"].version == snowball_wheel.version
 

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -89,6 +89,6 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog, tmp
     assert lockfile.packages["snowballstemmer"]["depends"] == []
     assert lockfile.packages["snowballstemmer"]["imports"] == ["snowball"]
     assert lockfile.packages["snowballstemmer"]["install_dir"] == "site"
-    assert lockfile.packages["snowballstemmer"]["unvendored_tests"] == False
+    assert not lockfile.packages["snowballstemmer"]["unvendored_tests"]
     assert lockfile.packages["snowballstemmer"]["version"] == snowball_wheel.version
 

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -1,6 +1,6 @@
 import pytest
-from pytest_pyodide import run_in_pyodide
 from conftest import mock_fetch_cls
+
 
 @pytest.mark.asyncio
 async def test_freeze(mock_fetch: mock_fetch_cls, mock_importlib: None) -> None:
@@ -66,7 +66,6 @@ async def test_freeze_fix_depends(
     assert dep2_metadata["imports"] == toplevel[2]
 
 
-
 def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog, tmp_path):
     from pyodide_lock import PyodideLockSpec
 
@@ -74,10 +73,12 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog, tmp
     snowball_wheel = wheel_catalog.get("snowballstemmer")
     url = snowball_wheel.url
 
-    lockfile_content = selenium.run_async(f"""
+    lockfile_content = selenium.run_async(
+        f"""
         await micropip.install("{url}")
         micropip.freeze()
-    """)
+    """
+    )
 
     lockfile_path = tmp_path / "lockfile.json"
     with open(lockfile_path, "w") as f:
@@ -91,4 +92,3 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog, tmp
     assert lockfile.packages["snowballstemmer"].install_dir == "site"
     assert not lockfile.packages["snowballstemmer"].unvendored_tests
     assert lockfile.packages["snowballstemmer"].version == snowball_wheel.version
-

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -67,7 +67,7 @@ async def test_freeze_fix_depends(
 
 
 
-def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog):
+def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog, tmp_path):
     from pyodide_lock import PyodideLockSpec
 
     selenium = selenium_standalone_micropip
@@ -79,5 +79,16 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog):
         micropip.freeze()
     """)
 
-    lockfile = PyodideLockSpec.from_json(lockfile_content)
-    print(lockfile)
+    lockfile_path = tmp_path / "lockfile.json"
+    with open(lockfile_path, "w") as f:
+        f.write(lockfile_content)
+
+    lockfile = PyodideLockSpec.from_json(lockfile_path)
+    assert lockfile.packages["snowballstemmer"]["file_name"] == url
+    assert lockfile.packages["snowballstemmer"]["name"] == "snowballstemmer"
+    assert lockfile.packages["snowballstemmer"]["depends"] == []
+    assert lockfile.packages["snowballstemmer"]["imports"] == ["snowball"]
+    assert lockfile.packages["snowballstemmer"]["install_dir"] == "site"
+    assert lockfile.packages["snowballstemmer"]["unvendored_tests"] == False
+    assert lockfile.packages["snowballstemmer"]["version"] == snowball_wheel.version
+

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -1,6 +1,6 @@
 import pytest
+from pytest_pyodide import run_in_pyodide
 from conftest import mock_fetch_cls
-
 
 @pytest.mark.asyncio
 async def test_freeze(mock_fetch: mock_fetch_cls, mock_importlib: None) -> None:
@@ -64,3 +64,20 @@ async def test_freeze_fix_depends(
     assert pkg_metadata["imports"] == toplevel[0]
     assert dep1_metadata["imports"] == toplevel[1]
     assert dep2_metadata["imports"] == toplevel[2]
+
+
+
+def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog):
+    from pyodide_lock import PyodideLockSpec
+
+    selenium = selenium_standalone_micropip
+    snowball_wheel = wheel_catalog.get("snowballstemmer")
+    url = snowball_wheel.url
+
+    lockfile_content = selenium.run(f"""
+        await micropip.install("{url}")
+        return micropip.freeze()
+    """)
+
+    lockfile = PyodideLockSpec.from_json(lockfile_content)
+    print(lockfile)

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -74,7 +74,7 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog):
     snowball_wheel = wheel_catalog.get("snowballstemmer")
     url = snowball_wheel.url
 
-    lockfile_content = selenium.run(f"""
+    lockfile_content = selenium.run_async(f"""
         await micropip.install("{url}")
         return micropip.freeze()
     """)

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -76,7 +76,7 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog):
 
     lockfile_content = selenium.run_async(f"""
         await micropip.install("{url}")
-        return micropip.freeze()
+        micropip.freeze()
     """)
 
     lockfile = PyodideLockSpec.from_json(lockfile_content)

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -87,7 +87,7 @@ def test_freeze_lockfile_compat(selenium_standalone_micropip, wheel_catalog, tmp
     assert lockfile.packages["snowballstemmer"].file_name == url
     assert lockfile.packages["snowballstemmer"].name == "snowballstemmer"
     assert lockfile.packages["snowballstemmer"].depends == []
-    assert lockfile.packages["snowballstemmer"].imports == ["snowball"]
+    assert lockfile.packages["snowballstemmer"].imports == ["snowballstemmer"]
     assert lockfile.packages["snowballstemmer"].install_dir == "site"
     assert not lockfile.packages["snowballstemmer"].unvendored_tests
     assert lockfile.packages["snowballstemmer"].version == snowball_wheel.version


### PR DESCRIPTION
Add a new test case to test the output of micropip.freeze() with PyodideLockSpec defined in pyodide-lock.

Related: #107 