### PR TITLE
Fix regression in loading package from local filesystem in Node

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
         test-config: [
           # FIXME: recent version of chrome gets timeout
           {runner: selenium, runtime: chrome, runtime-version: "125" },
+          {runner: selenium, runtime: node, runtime-version: "22" },
         ]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2024/11/11
+
+### Fixed
+
+- Fixed bug that prevented package installation from `file:` path in Node.js environment.
+  [#155](https://github.com/pyodide/micropip/pull/155)
+
 ## [0.7.0] - 2024/11/09
 
 ### Fixed

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -149,7 +149,7 @@ class WheelInfo:
         return requires
 
     async def _fetch_bytes(self, fetch_kwargs: dict[str, Any]):
-        if self.parsed_url.scheme not in ("https", "http", "emfs"):
+        if self.parsed_url.scheme not in ("https", "http", "emfs", "file"):
             # Don't raise ValueError it gets swallowed
             raise TypeError(
                 f"Cannot download from a non-remote location: {self.url!r} ({self.parsed_url!r})"


### PR DESCRIPTION
There is a bug in micropip 0.7.0 that causes Node to fail to load packages from the local filesystem.

I also enabled Node CI to detect this kind of bug.