### PR TITLE
Hardcode support for platform pyodide_wasm32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+ - Fix a bug that prevented some wasm32 wheel to be recognized as compatible with pyodide
+  [#159](https://github.com/pyodide/micropip/pull/159)
+
 ## [0.7.1] - 2024/11/11
 
 ### Fixed

--- a/micropip/package_index.py
+++ b/micropip/package_index.py
@@ -214,6 +214,9 @@ def _fast_check_incompatibility(filename: str) -> bool:
     if not filename.endswith(".whl"):
         return False
 
+    if filename.endswith("wasm32.whl") and sys.platform == "emscripten":
+        return True
+
     if sys.platform not in filename and not filename.endswith("-none-any.whl"):
         return False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from importlib.metadata import distribution
 
 import pytest
 from conftest import CPVER, EMSCRIPTEN_VER, PLATFORM
+from pytest_pyodide import run_in_pyodide
 
 import micropip._utils as _utils
 
@@ -101,6 +102,18 @@ def test_check_compatible(mock_platform, interp, abi, arch, ctx):
     wheel_name = f"{pkg}-{interp}-{abi}-{arch}.whl"
     with ctx:
         check_compatible(wheel_name)
+
+
+@run_in_pyodide
+def test_check_compatible_wasm32(selenium_standalone_micropip):
+    """
+    Here we check in particular that pyodide_2024_0_wasm32 wheels are seen as
+    compatible as the platform is emscripten
+    """
+    from micropip._utils import check_compatible
+
+    wheel_name = "pywavelets-1.8.0.dev0-cp312-cp312-pyodide_2024_0_wasm32.whl"
+    check_compatible(wheel_name)
 
 
 _best_tag_test_cases = (


### PR DESCRIPTION
Also cahnge some Generators to Tuple, as it is not the first time that while debugging I exaust the generator when printing logs; and this make micropip installing the package to fail.

I don't like it; this feels like a hack, but it works, and I woudl be happy to get more guidance.

Also one weird thing, is if I installl pywavelets nightly, it installs numpy stable; while the index does have a numpy nightly;

And with the same config, if I ask it to install numpy; it does install numpy nightly.

So there is something wonkey in recursive dependency handling of indexes.