### PR TITLE
Add basic integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
             --maxfail=15 \
             --runner=${{ matrix.test-config.runner }} \
             --rt ${{ matrix.test-config.runtime }}
-      
+
       - name: Run integration tests
         if: needs.check-integration-test-trigger.outputs.run-integration-test
         shell: bash -l {0}
@@ -76,7 +76,7 @@ jobs:
         if: ${{ github.event.repo.name == 'pyodide/micropip' || github.event_name == 'pull_request' }}
         with:
           fail_ci_if_error: false
-  
+
   check-integration-test-trigger:
     name: test-integration-test-trigger
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    needs: [check-integration-test-trigger]
     env:
       DISPLAY: :99
     strategy:
@@ -51,7 +52,19 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pytest -v \
+          pytest -v tests \
+            --cov=micropip \
+            --durations=10 \
+            --dist-dir=./dist/ \
+            --maxfail=15 \
+            --runner=${{ matrix.test-config.runner }} \
+            --rt ${{ matrix.test-config.runtime }}
+      
+      - name: Run integration tests
+        if: needs.check-integration-test-trigger.outputs.run-integration-test
+        shell: bash -l {0}
+        run: |
+          pytest -v tests \
             --cov=micropip \
             --durations=10 \
             --dist-dir=./dist/ \
@@ -63,6 +76,32 @@ jobs:
         if: ${{ github.event.repo.name == 'pyodide/micropip' || github.event_name == 'pull_request' }}
         with:
           fail_ci_if_error: false
+  
+  check-integration-test-trigger:
+    name: test-integration-test-trigger
+    runs-on: ubuntu-latest
+    outputs:
+      run-integration-test: ${{ steps.check-integration-test-trigger.outputs.trigger }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - id: check-integration-test-trigger
+        name: Check integration test trigger
+        shell: bash
+        run: |
+          set -e -x
+
+          COMMIT_MSG=$(git log --no-merges -1 --oneline)
+
+          # The integration tests will be triggered on push or on pull_request when the commit
+          # message contains "[integration]" or if it is pushed to main branch.
+          if [[ "$GITHUB_EVENT_NAME" == push && "$GITHUB_REF" == refs/heads/main ||
+                "$COMMIT_MSG" =~ \[integration\] ]]; then
+              echo "trigger=true" >> "$GITHUB_OUTPUT"
+          fi
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,8 @@ jobs:
         if: needs.check-integration-test-trigger.outputs.run-integration-test
         shell: bash -l {0}
         run: |
-          pytest -v tests \
+          pytest -v tests/integration \
+            --integration \
             --cov=micropip \
             --durations=10 \
             --dist-dir=./dist/ \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: "3.11"
+  python: "3.12"
 
 exclude: (^micropip/externals|^tests/vendored|^tests/test_data)
 repos:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,13 @@ def pytest_addoption(parser):
         help="Run tests that query remote package indexes.",
     )
 
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=None,
+        help="Run integration tests.",
+    )
+
 
 EMSCRIPTEN_VER = "3.1.14"
 PLATFORM = f"emscripten_{EMSCRIPTEN_VER.replace('.', '_')}_wasm32"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -60,7 +60,7 @@ def test_integration_uninstall_basic(selenium_standalone_micropip, pytestconfig)
 
         micropip.uninstall("snowballstemmer")
 
-        packages = await micropip.list()
+        packages = micropip.list()
         assert "snowballstemmer" not in packages
 
     _run(selenium_standalone_micropip)
@@ -81,6 +81,6 @@ def test_integration_freeze_basic(selenium_standalone_micropip, pytestconfig):
         snowballstemmer.stemmer("english")
 
         lockfile = micropip.freeze()
-        assert "snowballstemmer" in json.loads(lockfile)
+        assert "snowballstemmer" in json.loads(lockfile)["packages"]
 
     _run(selenium_standalone_micropip)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,12 +5,20 @@
 # To prevent sending many requests to remote servers, these tests are disabled by default.
 # To run these tests locally, invoke pytest with the `--integration` flag.
 
+import pytest
 from pytest_pyodide import run_in_pyodide
 
 
-def test_integration_install_basic(selenium_standalone_micropip, pytestconfig):
-    pytestconfig.getoption("--integration", skip=True)
+def integration_test_only(func):
+    def wrapper(selenium_standalone_micropip, pytestconfig):
+        if not pytestconfig.getoption("--integration"):
+            pytest.skip("Integration tests are skipped. Use --integration to run them.")
+        func(selenium_standalone_micropip, pytestconfig)
+    return wrapper
 
+
+@integration_test_only
+def test_integration_install_basic(selenium_standalone_micropip, pytestconfig):
     @run_in_pyodide
     async def _run(selenium):
         import micropip
@@ -24,9 +32,8 @@ def test_integration_install_basic(selenium_standalone_micropip, pytestconfig):
     _run(selenium_standalone_micropip)
 
 
+@integration_test_only
 def test_integration_list_basic(selenium_standalone_micropip, pytestconfig):
-    pytestconfig.getoption("--integration", skip=True)
-
     @run_in_pyodide
     async def _run(selenium):
         import micropip
@@ -39,9 +46,8 @@ def test_integration_list_basic(selenium_standalone_micropip, pytestconfig):
     _run(selenium_standalone_micropip)
 
 
+@integration_test_only
 def test_integration_uninstall_basic(selenium_standalone_micropip, pytestconfig):
-    pytestconfig.getoption("--integration", skip=True)
-
     @run_in_pyodide
     async def _run(selenium):
         import micropip
@@ -60,9 +66,8 @@ def test_integration_uninstall_basic(selenium_standalone_micropip, pytestconfig)
     _run(selenium_standalone_micropip)
 
 
+@integration_test_only
 def test_integration_freeze_basic(selenium_standalone_micropip, pytestconfig):
-    pytestconfig.getoption("--integration", skip=True)
-
     @run_in_pyodide
     async def _run(selenium):
         import json

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -33,7 +33,7 @@ def test_integration_list_basic(selenium_standalone_micropip, pytestconfig):
 
         await micropip.install("snowballstemmer")
 
-        packages = await micropip.list()
+        packages = micropip.list()
         assert "snowballstemmer" in packages
 
     _run(selenium_standalone_micropip)
@@ -52,7 +52,7 @@ def test_integration_uninstall_basic(selenium_standalone_micropip, pytestconfig)
 
         snowballstemmer.stemmer("english")
 
-        await micropip.uninstall("snowballstemmer")
+        micropip.uninstall("snowballstemmer")
 
         packages = await micropip.list()
         assert "snowballstemmer" not in packages
@@ -65,6 +65,8 @@ def test_integration_freeze_basic(selenium_standalone_micropip, pytestconfig):
 
     @run_in_pyodide
     async def _run(selenium):
+        import json
+
         import micropip
 
         await micropip.install("snowballstemmer")
@@ -74,6 +76,6 @@ def test_integration_freeze_basic(selenium_standalone_micropip, pytestconfig):
         snowballstemmer.stemmer("english")
 
         lockfile = micropip.freeze()
-        assert "snowballstemmer" in lockfile["packages"]
+        assert "snowballstemmer" in json.loads(lockfile)
 
     _run(selenium_standalone_micropip)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,79 @@
+# integration tests for micropip
+# these test often requires querying to the real packages existing in PyPI,
+# to test the micropip's ability to install packages from real world package indexes.
+
+# To prevent sending many requests to remote servers, these tests are disabled by default.
+# To run these tests locally, add `--integration` flag, when inovking pytest.
+
+from pytest_pyodide import run_in_pyodide
+
+
+def test_integration_install_basic(selenium_standalone_micropip, pytestconfig):
+    pytestconfig.getoption("--integration", skip=True)
+
+    @run_in_pyodide
+    async def _run(selenium):
+        import micropip
+
+        await micropip.install("snowballstemmer")
+
+        import snowballstemmer
+
+        snowballstemmer.stemmer("english")
+
+    _run(selenium_standalone_micropip)
+
+
+def test_integration_list_basic(selenium_standalone_micropip, pytestconfig):
+    pytestconfig.getoption("--integration", skip=True)
+
+    @run_in_pyodide
+    async def _run(selenium):
+        import micropip
+
+        await micropip.install("snowballstemmer")
+
+        packages = await micropip.list()
+        assert "snowballstemmer" in packages
+
+    _run(selenium_standalone_micropip)
+
+
+def test_integration_uninstall_basic(selenium_standalone_micropip, pytestconfig):
+    pytestconfig.getoption("--integration", skip=True)
+
+    @run_in_pyodide
+    async def _run(selenium):
+        import micropip
+
+        await micropip.install("snowballstemmer")
+
+        import snowballstemmer
+
+        snowballstemmer.stemmer("english")
+
+        await micropip.uninstall("snowballstemmer")
+
+        packages = await micropip.list()
+        assert "snowballstemmer" not in packages
+
+    _run(selenium_standalone_micropip)
+
+
+def test_integration_freeze_basic(selenium_standalone_micropip, pytestconfig):
+    pytestconfig.getoption("--integration", skip=True)
+
+    @run_in_pyodide
+    async def _run(selenium):
+        import micropip
+
+        await micropip.install("snowballstemmer")
+
+        import snowballstemmer
+
+        snowballstemmer.stemmer("english")
+
+        lockfile = micropip.freeze()
+        assert "snowballstemmer" in lockfile["packages"]
+
+    _run(selenium_standalone_micropip)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,5 +1,5 @@
-# integration tests for micropip
-# these test often requires querying to the real packages existing in PyPI,
+# Integration tests for micropip
+# These test often requires querying to the real packages existing in PyPI,
 # to test the micropip's ability to install packages from real world package indexes.
 
 # To prevent sending many requests to remote servers, these tests are disabled by default.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,7 +3,7 @@
 # to test the micropip's ability to install packages from real world package indexes.
 
 # To prevent sending many requests to remote servers, these tests are disabled by default.
-# To run these tests locally, add `--integration` flag, when inovking pytest.
+# To run these tests locally, invoke pytest with the `--integration` flag.
 
 from pytest_pyodide import run_in_pyodide
 

--- a/tests/integration/test_remote_indexes.py
+++ b/tests/integration/test_remote_indexes.py
@@ -1,7 +1,7 @@
 # This file contains tests that actually query remote package indexes,
 # to ensure that micropip works with real-world package indexes.
 # Since running these tests will send many requests to remote servers,
-# these tests are disabled by default in CI.
+# these tests are disabled by default in CI and local testing.
 #
 # To run these tests, add `--run-remote-index-tests` flag, or
 # these tests can also be run in Github Actions manually.

--- a/tests/integration/test_remote_indexes.py
+++ b/tests/integration/test_remote_indexes.py
@@ -1,7 +1,7 @@
 # This file contains tests that actually query remote package indexes,
 # to ensure that micropip works with real-world package indexes.
 # Since running these tests will send many requests to remote servers,
-# these tests are disabled by default.
+# these tests are disabled by default in CI.
 #
 # To run these tests, add `--run-remote-index-tests` flag, or
 # these tests can also be run in Github Actions manually.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,28 +6,6 @@ from pytest_pyodide import run_in_pyodide
 import micropip
 
 
-def test_install_simple(selenium_standalone_micropip):
-    selenium = selenium_standalone_micropip
-    assert (
-        selenium.run_js(
-            """
-            return await pyodide.runPythonAsync(`
-                import os
-                import micropip
-                from pyodide.ffi import to_js
-                # Package 'pyodide-micropip-test' has dependency on 'snowballstemmer'
-                # It is used to test markers support
-                await micropip.install('pyodide-micropip-test')
-                import snowballstemmer
-                stemmer = snowballstemmer.stemmer('english')
-                to_js(stemmer.stemWords('go going goes gone'.split()))
-            `);
-            """
-        )
-        == ["go", "go", "goe", "gone"]
-    )
-
-
 def test_install_custom_url(selenium_standalone_micropip, wheel_catalog):
     selenium = selenium_standalone_micropip
     snowball_wheel = wheel_catalog.get("snowballstemmer")


### PR DESCRIPTION
This adds basic integration tests for micropip, which queries to real world packages indexes (PyPI).

To prevent DoS, this is disabled by default in PR, and only run when `[integration]` is included in the PR or when the PR is merged and pushed to the main branch.