### PR TITLE
Pre-commit: Tighten up ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.6.9"
+    rev: "v0.8.3"
     hooks:
       - id: ruff
         args: [--fix]
@@ -29,13 +29,12 @@ repos:
       - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.2"
+    rev: "v1.13.0"
     hooks:
       - id: mypy
         args: []
         additional_dependencies: &mypy-deps
           - pytest
-
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,9 @@ test = [
   "pyodide-lock==v0.1.0a8",
 ]
 
-
 [project.urls]
 "Homepage" = "https://github.com/pyodide/micropip"
 "Bug Tracker" = "https://github.com/pyodide/micropip/issues"
-
 
 
 [build-system]
@@ -41,23 +39,18 @@ build-backend = "setuptools.build_meta"
 write_to = "micropip/_version.py"
 
 [tool.ruff]
+line-length = 122
 lint.select = [
   "E",     # pycodestyles
   "W",     # pycodestyles
   "F",     # pyflakes
-  "B0",    # bugbear (all B0* checks enabled by default)
-  "B904",  # bugbear (Within an except clause, raise exceptions with raise ... from err)
-  "B905",  # bugbear (zip() without an explicit strict= parameter set.)
+  "B",     # bugbear
   "UP",    # pyupgrade
   "I",     # isort
   "PGH",   # pygrep-hooks
   "G",     # flake8-logging-format
 ]
-# Remove E999 once pattern matching is supported
-# https://github.com/charliermarsh/ruff/issues/282
-lint.ignore = ["E402", "E501", "E731", "E741", "E999"]
-target-version = "py311"
-
+target-version = "py312"
 
 [tool.ruff.lint.isort]
 known-first-party = [


### PR DESCRIPTION
% `pre-commit autoupdate && pre-commit run --all-files`

No code changes were required for the following:
1. Set `tool.ruff.line-length = 122`
2. Enable all ruff rules B for bugbear.
3. Remove all `tool.ruff.lint.ignore`.
4. Set `tool.ruff.target-version = "py312"`

https://docs.astral.sh/ruff/rules