### PR TITLE
Ruff rules for comprehensions and performance

### DIFF
--- a/micropip/externals/mousebender/simple.py
+++ b/micropip/externals/mousebender/simple.py
@@ -5,7 +5,7 @@ import html
 import html.parser
 import urllib.parse
 import warnings
-from typing import Any, Dict, Literal, TypeAlias, TypedDict  # noqa: UP035 mypy needs `Dict`
+from typing import Any, Literal, TypedDict
 
 import packaging.utils
 
@@ -37,17 +37,17 @@ _Meta_1_0 = TypedDict("_Meta_1_0", {"api-version": Literal["1.0"]})
 _Meta_1_1 = TypedDict("_Meta_1_1", {"api-version": Literal["1.1"]})
 
 
-_HashesDict: TypeAlias = Dict[str, str]  # noqa: UP006,UP040 mypy is not yet ready to for `type` and `dict`.
+_HashesDict: type = dict[str, str]  # Mypy upgrade should fix -- `_HashesDict: TypeAlias = Dict[str, str]`
 
 _OptionalProjectFileDetails_1_0 = TypedDict(
     "_OptionalProjectFileDetails_1_0",
     {
         "requires-python": str,
-        "dist-info-metadata": bool | _HashesDict,
+        "dist-info-metadata": bool | _HashesDict,  # type: ignore[valid-type]
         "gpg-sig": bool,
         "yanked": bool | str,
         # PEP-714
-        "core-metadata": bool | _HashesDict,
+        "core-metadata": bool | _HashesDict,  # type: ignore[valid-type]
     },
     total=False,
 )
@@ -58,20 +58,20 @@ class ProjectFileDetails_1_0(_OptionalProjectFileDetails_1_0):
 
     filename: str
     url: str
-    hashes: _HashesDict
+    hashes: _HashesDict  # type: ignore[valid-type]
 
 
 _OptionalProjectFileDetails_1_1 = TypedDict(
     "_OptionalProjectFileDetails_1_1",
     {
         "requires-python": str,
-        "dist-info-metadata": bool | _HashesDict,
+        "dist-info-metadata": bool | _HashesDict,  # type: ignore[valid-type]
         "gpg-sig": bool,
         "yanked": bool | str,
         # PEP 700
         "upload-time": str,
         # PEP 714
-        "core-metadata": bool | _HashesDict,
+        "core-metadata": bool | _HashesDict,  # type: ignore[valid-type]
     },
     total=False,
 )
@@ -82,7 +82,7 @@ class ProjectFileDetails_1_1(_OptionalProjectFileDetails_1_1):
 
     filename: str
     url: str
-    hashes: _HashesDict
+    hashes: _HashesDict  # type: ignore[valid-type]
     # PEP 700
     size: int
 
@@ -105,7 +105,7 @@ class ProjectDetails_1_1(TypedDict):
     versions: list[str]
 
 
-ProjectDetails: TypeAlias = ProjectDetails_1_0 | ProjectDetails_1_1  # noqa: UP040 mypy is not yet ready to for `type`.
+ProjectDetails: type = ProjectDetails_1_0 | ProjectDetails_1_1  # type: ignore[assignment]  # Mypy wants `UnionType`
 
 
 def _check_version(tag: str, attrs: dict[str, str | None]) -> None:

--- a/micropip/externals/mousebender/simple.py
+++ b/micropip/externals/mousebender/simple.py
@@ -5,10 +5,9 @@ import html
 import html.parser
 import urllib.parse
 import warnings
-from typing import Any, Dict, List, Optional, Union, Literal, TypeAlias, TypedDict
+from typing import Any, Dict, Literal, TypeAlias, TypedDict  # noqa: UP035 mypy needs `Dict`
 
 import packaging.utils
-
 
 ACCEPT_JSON_V1 = "application/vnd.pypi.simple.v1+json"
 
@@ -38,17 +37,17 @@ _Meta_1_0 = TypedDict("_Meta_1_0", {"api-version": Literal["1.0"]})
 _Meta_1_1 = TypedDict("_Meta_1_1", {"api-version": Literal["1.1"]})
 
 
-_HashesDict: TypeAlias = Dict[str, str]
+_HashesDict: TypeAlias = Dict[str, str]  # noqa: UP006,UP040 mypy is not yet ready to for `type` and `dict`.
 
 _OptionalProjectFileDetails_1_0 = TypedDict(
     "_OptionalProjectFileDetails_1_0",
     {
         "requires-python": str,
-        "dist-info-metadata": Union[bool, _HashesDict],
+        "dist-info-metadata": bool | _HashesDict,
         "gpg-sig": bool,
-        "yanked": Union[bool, str],
+        "yanked": bool | str,
         # PEP-714
-        "core-metadata": Union[bool, _HashesDict],
+        "core-metadata": bool | _HashesDict,
     },
     total=False,
 )
@@ -66,13 +65,13 @@ _OptionalProjectFileDetails_1_1 = TypedDict(
     "_OptionalProjectFileDetails_1_1",
     {
         "requires-python": str,
-        "dist-info-metadata": Union[bool, _HashesDict],
+        "dist-info-metadata": bool | _HashesDict,
         "gpg-sig": bool,
-        "yanked": Union[bool, str],
+        "yanked": bool | str,
         # PEP 700
         "upload-time": str,
         # PEP 714
-        "core-metadata": Union[bool, _HashesDict],
+        "core-metadata": bool | _HashesDict,
     },
     total=False,
 )
@@ -103,13 +102,13 @@ class ProjectDetails_1_1(TypedDict):
     name: packaging.utils.NormalizedName
     files: list[ProjectFileDetails_1_1]
     # PEP 700
-    versions: List[str]
+    versions: list[str]
 
 
-ProjectDetails: TypeAlias = Union[ProjectDetails_1_0, ProjectDetails_1_1]
+ProjectDetails: TypeAlias = ProjectDetails_1_0 | ProjectDetails_1_1  # noqa: UP040 mypy is not yet ready to for `type`.
 
 
-def _check_version(tag: str, attrs: Dict[str, Optional[str]]) -> None:
+def _check_version(tag: str, attrs: dict[str, str | None]) -> None:
     if (
         tag == "meta"
         and attrs.get("name") == "pypi:repository-version"
@@ -126,11 +125,11 @@ def _check_version(tag: str, attrs: Dict[str, Optional[str]]) -> None:
 
 class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
     def __init__(self) -> None:
-        self.archive_links: List[Dict[str, Any]] = []
+        self.archive_links: list[dict[str, Any]] = []
         super().__init__()
 
     def handle_starttag(
-        self, tag: str, attrs_list: list[tuple[str, Optional[str]]]
+        self, tag: str, attrs_list: list[tuple[str, str | None]]
     ) -> None:
         attrs = dict(attrs_list)
         _check_version(tag, attrs)
@@ -149,7 +148,7 @@ class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
         _, _, raw_filename = parsed_url.path.rpartition("/")
         filename = urllib.parse.unquote(raw_filename)
         url = urllib.parse.urlunparse((*parsed_url[:5], ""))
-        args: Dict[str, Any] = {"filename": filename, "url": url}
+        args: dict[str, Any] = {"filename": filename, "url": url}
         # PEP 503:
         # The URL SHOULD include a hash in the form of a URL fragment with the
         # following syntax: #<hashname>=<hashvalue> ...
@@ -210,7 +209,7 @@ def from_project_details_html(html: str, name: str) -> ProjectDetails_1_0:
     """
     parser = _ArchiveLinkHTMLParser()
     parser.feed(html)
-    files: List[ProjectFileDetails_1_0] = []
+    files: list[ProjectFileDetails_1_0] = []
     for archive_link in parser.archive_links:
         details: ProjectFileDetails_1_0 = {
             "filename": archive_link["filename"],

--- a/micropip/install.py
+++ b/micropip/install.py
@@ -28,7 +28,7 @@ async def install(
         if isinstance(requirements, str):
             requirements = [requirements]
 
-        fetch_kwargs = dict()
+        fetch_kwargs = {}
 
         if credentials:
             fetch_kwargs["credentials"] = credentials
@@ -84,10 +84,9 @@ async def install(
             )
 
         # Now install PyPI packages
-        for wheel in transaction.wheels:
-            # detect whether the wheel metadata is from PyPI or from custom location
-            # wheel metadata from PyPI has SHA256 checksum digest.
-            wheel_promises.append(wheel.install(wheel_base))
+        # detect whether the wheel metadata is from PyPI or from custom location
+        # wheel metadata from PyPI has SHA256 checksum digest.
+        wheel_promises.extend(wheel.install(wheel_base) for wheel in transaction.wheels)
 
         await asyncio.gather(*wheel_promises)
 

--- a/micropip/package.py
+++ b/micropip/package.py
@@ -30,8 +30,7 @@ def _format_table(headers: list[str], table: Iterable[Iterable[Any]]) -> str:
 
     rows.append(format_row(headers, col_width))
     rows.append(format_row([""] * len(col_width), col_width, filler="-"))
-    for line in table:
-        rows.append(format_row(line, col_width))
+    rows.extend(format_row(line, col_width) for line in table)
 
     return "\n".join(rows)
 

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -48,9 +48,9 @@ class Transaction:
         self,
         requirements: list[str] | list[Requirement],
     ) -> None:
-        requirement_promises = []
-        for requirement in requirements:
-            requirement_promises.append(self.add_requirement(requirement))
+        requirement_promises = [
+            self.add_requirement(requirement) for requirement in requirements
+        ]
 
         await asyncio.gather(*requirement_promises)
 
@@ -132,7 +132,7 @@ class Transaction:
             # self.ctx_extras is empty and hence the eval_marker() function
             # will not be called at all.
             if not req.marker.evaluate(self.ctx) and not any(
-                [eval_marker(e) for e in self.ctx_extras]
+                eval_marker(e) for e in self.ctx_extras
             ):
                 return
         # Is some version of this package is already installed?

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -52,7 +52,8 @@ class WheelInfo:
     _metadata: Metadata | None = None  # Wheel metadata.
     _requires: list[Requirement] | None = None  # List of requirements.
 
-    # Path to the .dist-info directory. This is only available after extracting the wheel, i.e. after calling `extract()`.
+    # Path to the .dist-info directory.
+    # This is only available after extracting the wheel, i.e. after calling `extract()`.
     _dist_info: Path | None = None
 
     def __post_init__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,17 +39,22 @@ build-backend = "setuptools.build_meta"
 write_to = "micropip/_version.py"
 
 [tool.ruff]
-line-length = 122
+line-length = 120
 lint.select = [
-  "E",     # pycodestyles
-  "W",     # pycodestyles
-  "F",     # pyflakes
   "B",     # bugbear
-  "UP",    # pyupgrade
-  "I",     # isort
-  "PGH",   # pygrep-hooks
+  "C4",    # flake8-comprehensions
+  "C90",   # mccabe code complexity
+  "E",     # pycodestyle errors
+  "F",     # pyflakes
   "G",     # flake8-logging-format
+  "I",     # isort
+  "PERF",  # perflint
+  "PGH",   # pygrep-hooks
+  "UP",    # pyupgrade
+  "W",     # pycodestyle whitespace
 ]
+lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments = true
+lint.mccabe.max-complexity = 13
 target-version = "py312"
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ build-backend = "setuptools.build_meta"
 write_to = "micropip/_version.py"
 
 [tool.ruff]
+exclude = ["micropip/externals"]
 line-length = 120
 lint.select = [
   "B",     # bugbear

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -249,7 +249,7 @@ async def test_install_with_credentials(selenium):
     fetch_response_mock = MagicMock()
 
     async def myfunc():
-        return json.dumps(dict())
+        return json.dumps({})
 
     fetch_response_mock.string.side_effect = myfunc
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -35,7 +35,7 @@ def test_Metadata_requires(metadata_path, extras, expected):
     m = Metadata(metadata)
 
     reqs = m.requires(extras)
-    reqs_set = set([r.name for r in reqs])
+    reqs_set = {r.name for r in reqs}
     assert reqs_set == set(expected)
 
 


### PR DESCRIPTION
% `ruff check --select=C4,C90,PERF --statistics`
```
3	C408   	[*] unnecessary-collection-call
3	C901   	[ ] complex-structure
3	PERF401	[ ] manual-list-comprehension
1	C403   	[*] unnecessary-list-comprehension-set
1	C419   	[*] unnecessary-comprehension-in-call
[*] fixable with `ruff check --fix`
```

In `micropip/externals/mousebender/simple.py`, Mypy is a bit behind pyupgrade on Python 3.12.

% `ruff rule C408`
# unnecessary-collection-call (C408)

Derived from the **flake8-comprehensions** linter.

Fix is always available.

## What it does
Checks for unnecessary `dict()`, `list()` or `tuple()` calls that can be
rewritten as empty literals.

## Why is this bad?
It's unnecessary to call, e.g., `dict()` as opposed to using an empty
literal (`{}`). The former is slower because the name `dict` must be
looked up in the global scope in case it has been rebound.

## Examples
```python
dict()
dict(a=1, b=2)
list()
tuple()
```

Use instead:
```python
{}
{"a": 1, "b": 2}
[]
()
```

## Fix safety
This rule's fix is marked as unsafe, as it may occasionally drop comments
when rewriting the call. In most cases, though, comments will be preserved.

## Options
- `lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments`
