### PR TITLE
Add support for constraints, install in topological order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for constraining indirect dependencies via
   `micropip.install(..., constraints=[...])`. and `micropip.set_constraints([...])`
-  [#xyz](https://github.com/pyodide/micropip/pull/xyz)
+  [#177](https://github.com/pyodide/micropip/pull/177)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for constraining indirect dependencies via
+- Added support for constraining resolved requirements via
   `micropip.install(..., constraints=[...])`. and `micropip.set_constraints([...])`
   [#177](https://github.com/pyodide/micropip/pull/177)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added support for constraining indirect dependencies via
+  `micropip.install(..., constraints=[...])`. and `micropip.set_constraints([...])`
+  [#xyz](https://github.com/pyodide/micropip/pull/xyz)
+
 ### Fixed
 
 - Fix a bug that prevented non-standard relative urls to be treated as such

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `micropip.install` now installs packages in topological order: previously all packages
+  from `pyodide-lock.json` were installed before any wheels from indexes or custom URLs.
+  [#177](https://github.com/pyodide/micropip/pull/177)
+
 ### Added
 
 - Added support for constraining resolved requirements via
-  `micropip.install(..., constraints=[...])`. and `micropip.set_constraints([...])`
+  `micropip.install(..., constraints=[...])`. and `micropip.set_constraints([...])`.
   [#177](https://github.com/pyodide/micropip/pull/177)
 
 ### Fixed

--- a/docs/project/usage.md
+++ b/docs/project/usage.md
@@ -71,7 +71,8 @@ You can pass multiple packages to `micropip.install`:
 await micropip.install(["pkg1", "pkg2"])
 ```
 
-You can specify additional constraints:
+A dependency can specify be refined per the [PEP-508] spec:
+
 
 ```python
 await micropip.install("snowballstemmer==2.2.0")
@@ -79,10 +80,31 @@ await micropip.install("snowballstemmer>=2.2.0")
 await micropip.install("snowballstemmer[all]")
 ```
 
+[PEP-508]: https://peps.python.org/pep-0508
+
+### Disabling dependency resolution
+
 micropip does dependency resolution by default, but you can disable it,
 this is useful if you want to install a package that has a dependency
 which is not a pure Python package, but it is not mandatory for your use case:
 
 ```python
 await micropip.install("pkg", deps=False)
+```
+
+### Constraining indirect dependencies
+
+Dependency resolution can be further customized with optional `constraints`: these
+provide the versions (or URLs of wheels)
+
+```python
+await micropip.install("pkg", constraints=["other-pkg ==0.1.1"])
+```
+
+Default `constraints` may be provided to be used by all subsequent calls to
+`micropip.install`:
+
+```python
+micropip.set_constraints = ["other-pkg ==0.1.1"]
+await micropip.install("pkg")
 ```

--- a/docs/project/usage.md
+++ b/docs/project/usage.md
@@ -96,7 +96,7 @@ await micropip.install("pkg", deps=False)
 
 Dependency resolution can be further customized with optional `constraints`:
 these modify both _direct_ and _indirect_ dependency resolutions, while direct URLs
-in either a requirement or constraint will generally bypass any other specifiers.
+in either a requirement or constraint will bypass any other specifiers.
 
 As described in the [`pip` documentation][pip-constraints], each constraint:
 
@@ -108,6 +108,8 @@ As described in the [`pip` documentation][pip-constraints], each constraint:
     - a URL
   - _must not_  request any `[extras]`
 
+Multiple constraints of the same canonical name are merged.
+
 Invalid constraints will be silently discarded, or logged if `verbose` is provided.
 
 ```python
@@ -116,11 +118,14 @@ await micropip.install(
     constraints=[
         "other-pkg==0.1.1",
         "some-other-pkg<2",
+        "some-other-pkg<3",                           # merged with the above
         "yet-another-pkg@https://example.com/yet_another_pkg-0.1.2-py3-none-any.whl",
         # silently discarded                          # why?
+        "yet-another-pkg >=1",                        # previously defined by URL
         "yet_another_pkg-0.1.2-py3-none-any.whl",     # missing name
         "something-completely[different] ==0.1.1",    # extras
         "package-with-no-version",                    # missing version or URL
+        "other-pkg ==0.0.1 ; python_version < '3'",   # not applicable
     ]
 )
 ```

--- a/docs/project/usage.md
+++ b/docs/project/usage.md
@@ -94,17 +94,31 @@ await micropip.install("pkg", deps=False)
 
 ### Constraining indirect dependencies
 
-Dependency resolution can be further customized with optional `constraints`: these
-provide the versions (or URLs of wheels)
+Dependency resolution can be further customized with optional `constraints`: as
+described in the [`pip`](https://pip.pypa.io/en/stable/user_guide/#constraints-files)
+documentation, these must provide a name and version (or URL), and may not request
+`[extras]`.
 
 ```python
-await micropip.install("pkg", constraints=["other-pkg ==0.1.1"])
+await micropip.install(
+    "pkg",
+    constraints=[
+        "other-pkg ==0.1.1",
+        "some-other-pkg <2",
+        "yet-another-pkg@https://example.com/yet_another_pkg-0.1.2-py3-none-any.whl",
+        # invalid examples                         # why?
+        # yet_another_pkg-0.1.2-py3-none-any.whl   # missing name
+        # something-completely[different] ==0.1.1  # extras
+        # package-with-no-version                  # missing version or URL
+    ]
+)
 ```
 
-Default `constraints` may be provided to be used by all subsequent calls to
-`micropip.install`:
+`micropip.set_constraints` replaces any default constraints for all subsequent
+calls to `micropip.install` that don't specify constraints:
 
 ```python
 micropip.set_constraints = ["other-pkg ==0.1.1"]
-await micropip.install("pkg")
+await micropip.install("pkg")                         # uses defaults
+await micropip.install("another-pkg", constraints=[]) # ignores defaults
 ```

--- a/docs/project/usage.md
+++ b/docs/project/usage.md
@@ -105,9 +105,8 @@ As described in the [`pip` documentation][pip-constraints], each constraint:
   - _must_ provide a name
   - _must_ provide exactly one of
     - a set of version specifiers
-    - a URL, and _may not_ request
+    - a URL
   - _must not_  request any `[extras]`
-
 
 Invalid constraints will be silently discarded, or logged if `verbose` is provided.
 

--- a/micropip/__init__.py
+++ b/micropip/__init__.py
@@ -9,6 +9,7 @@ _package_manager_singleton = PackageManager()
 
 install = _package_manager_singleton.install
 set_index_urls = _package_manager_singleton.set_index_urls
+set_constraints = _package_manager_singleton.set_constraints
 list = _package_manager_singleton.list
 freeze = _package_manager_singleton.freeze
 add_mock_package = _package_manager_singleton.add_mock_package

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -280,7 +280,7 @@ def validate_constraints(
     ----------
     constraints (list):
         A list of PEP-508 dependency specs, expected to contain both a package
-        name and at least one specififier.
+        name and at least one specifier or a direct URL.
 
     environment (optional dict):
         The markers for the current environment, such as OS, Python implementation.

--- a/micropip/install.py
+++ b/micropip/install.py
@@ -20,6 +20,7 @@ async def install(
     credentials: str | None = None,
     pre: bool = False,
     *,
+    constraints: list[str] | None = None,
     verbose: bool | int | None = None,
 ) -> None:
     with setup_logging().ctx_level(verbose) as logger:
@@ -49,6 +50,7 @@ async def install(
             fetch_kwargs=fetch_kwargs,
             verbose=verbose,
             index_urls=index_urls,
+            constraints=constraints,
         )
         await transaction.gather_requirements(requirements)
 

--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -323,3 +323,16 @@ class PackageManager:
             urls = [urls]
 
         self.index_urls = urls[:]
+
+    def set_constraints(self, constraints: List[str]):  # noqa: UP006
+        """
+        Set the default constraints to use when looking up packages.
+
+        Parameters
+        ----------
+        constraints
+            A list of PEP-508 requirements, each of which must include a name and
+            version, but no ``[extras]``.
+        """
+
+        self.constraints = constraints[:]

--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -26,6 +26,7 @@ class PackageManager:
 
         self.repodata_packages: dict[str, dict[str, Any]] = REPODATA_PACKAGES
         self.repodata_info: dict[str, str] = REPODATA_INFO
+        self.constraints: list[str] = []
 
         pass
 
@@ -38,6 +39,7 @@ class PackageManager:
         pre: bool = False,
         index_urls: list[str] | str | None = None,
         *,
+        constraints: list[str] | None = None,
         verbose: bool | int | None = None,
     ):
         """Install the given package and all of its dependencies.
@@ -122,6 +124,14 @@ class PackageManager:
             - If a list of URLs is provided, micropip will try each URL in order until
             it finds a package. If no package is found, an error will be raised.
 
+        constraints :
+
+            A list of requirements with versions/URLs which will be used only if
+            needed by any ``requirements``.
+
+            Unlike ``requirements``, the package name _must_ be provided in the
+            PEP-508 format e.g. ``pkgname@https://...``.
+
         verbose :
             Print more information about the process. By default, micropip does not
             change logger level. Setting ``verbose=True`` will print similar
@@ -130,6 +140,9 @@ class PackageManager:
         if index_urls is None:
             index_urls = self.index_urls
 
+        if constraints is None:
+            constraints = self.constraints
+
         return await install(
             requirements,
             index_urls,
@@ -137,6 +150,7 @@ class PackageManager:
             deps,
             credentials,
             pre,
+            constraints=constraints,
             verbose=verbose,
         )
 

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -55,7 +55,7 @@ class Transaction:
             if con.extras:
                 logger.debug("Transaction: discarding [extras] constraint: %s", con)
                 continue
-            if not con.url or len(con.specifier):
+            if not (con.url or len(con.specifier)):
                 logger.debug("Transaction: discarding versionless constraint: %s", con)
                 continue
             con.name = canonicalize_name(con.name)

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -36,6 +36,7 @@ class Transaction:
     failed: list[Requirement] = field(default_factory=list)
 
     verbose: bool | int | None = None
+    constraints: list[str] | None = None
 
     def __post_init__(self):
         # If index_urls is None, pyodide-lock.json have to be searched first.

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -50,13 +50,13 @@ class Transaction:
             self.index_urls == package_index.DEFAULT_INDEX_URLS
         )
 
-        self.constrained_reqs, messages = validate_constraints(self.constraints)
+        self.constrained_reqs, messages = validate_constraints(
+            self.constraints, self.ctx
+        )
 
         if self.verbose and messages:
-            for constraint, message in messages.items():
-                logger.info(
-                    "Transaction: constraint %s discarded: %s", constraint, message
-                )
+            for constraint, msg in messages.items():
+                logger.info("Transaction: constraint %s discarded: %s", constraint, msg)
 
     async def gather_requirements(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,6 @@ python_version = "3.12"
 show_error_codes = true
 warn_unreachable = true
 ignore_missing_imports = true
+
+[tool.coverage.html]
+show_contexts = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from packaging.utils import parse_wheel_filename
 from pytest_httpserver import HTTPServer
 from pytest_pyodide import spawn_web_server
+from pytest_pyodide.runner import JavascriptException
 
 
 def pytest_addoption(parser):
@@ -408,3 +409,45 @@ def mock_package_index_simple_html_api(httpserver):
         suffix="_simple.html",
         content_type="text/html",
     )
+
+
+@pytest.fixture(
+    params=[
+        None,
+        "pytest ==7.2.2",
+        "pytest >=7.2.1,<7.2.3",
+        "pytest @ {url}",
+        "pytest @ emfs:{wheel}",
+    ]
+)
+def valid_constraint(request, wheel_catalog):
+    wheel = wheel_catalog.get("pytest")
+    if not request.param:
+        return request.param
+    return request.param.format(url=wheel.url, wheel=wheel.url.split("/")[-1])
+
+
+INVALID_CONSTRAINT_MESSAGES = {
+    "": "parse",
+    "http://example.com": "name",
+    "a-package[with-extra]": "[extras]",
+    "a-package": "no version or URL",
+}
+
+
+@pytest.fixture(params=[*INVALID_CONSTRAINT_MESSAGES.keys()])
+def invalid_constraint(request):
+    return request.param
+
+
+@pytest.fixture
+def run_async_py_in_js(selenium_standalone_micropip):
+    def _run(*lines, error_match=None):
+        js = "\n".join(["await pyodide.runPythonAsync(`", *lines, "`);"])
+        if error_match:
+            with pytest.raises(JavascriptException, match=error_match):
+                selenium_standalone_micropip.run_js(js)
+        else:
+            selenium_standalone_micropip.run_js(js)
+
+    return _run

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -99,6 +99,29 @@ def test_install_mixed_case2(selenium_standalone_micropip, jinja2):
     )
 
 
+def test_install_constraints(selenium_standalone_micropip):
+    selenium = selenium_standalone_micropip
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
+            import micropip
+            await micropip.install(
+                "pytz",
+                constraints=["pytz == 2020.5"]
+            );
+        `);
+        """
+    )
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
+            import pytz
+            assert pytz.__version__ == "2020.5"
+        `);
+        """
+    )
+
+
 @pytest.mark.asyncio
 async def test_package_with_extra(mock_fetch):
     mock_fetch.add_pkg_version("depa")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -116,7 +116,27 @@ def test_install_constraints(selenium_standalone_micropip):
         """
         await pyodide.runPythonAsync(`
             import pytz
-            assert pytz.__version__ == "2020.5"
+            assert pytz.__version__ == "2020.5", pytz.__version__
+        `);
+        """
+    )
+
+def test_install_constraints_defaults(selenium_standalone_micropip):
+    selenium = selenium_standalone_micropip
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
+            import micropip
+            micropip.set_constraints(["pytz == 2020.5"])
+            await micropip.install("pytz");
+        `);
+        """
+    )
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
+            import pytz
+            assert pytz.__version__ == "2020.5", pytz.__version__
         `);
         """
     )

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -132,7 +132,7 @@ async def test_add_requirement_query_url(mock_importlib, wheel_base, monkeypatch
     pytest.importorskip("packaging")
     from micropip.transaction import Transaction
 
-    async def mock_add_wheel(self, wheel, extras, *, specifier=""):
+    async def mock_add_wheel(self, wheel, extras, *, specifier="", requested_by=None):
         self.mock_wheel = wheel
 
     monkeypatch.setattr(Transaction, "add_wheel", mock_add_wheel)
@@ -336,7 +336,7 @@ async def test_index_url_priority(
     # add_wheel is called only when the package is found in the index_urls
     add_wheel_called = None
 
-    async def mock_add_wheel(self, wheel, extras, *, specifier=""):
+    async def mock_add_wheel(self, wheel, extras, *, specifier="", requested_by=None):
         nonlocal add_wheel_called
         add_wheel_called = wheel
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -159,13 +159,29 @@ def test_validate_constraints_valid(valid_constraint):
     assert len(reqs) == len(constraints)
     assert not msgs
 
+    if not valid_constraint or "==" not in valid_constraint:
+        return
+
+    extra_constraint = valid_constraint.replace("==", ">=")
+    marker_valid_constraint = f"{extra_constraint} ; python_version>'2.7'"
+    marker_invalid_constraint = f"{extra_constraint} ; python_version<'3'"
+    constraints += [
+        extra_constraint,
+        marker_valid_constraint,
+        marker_invalid_constraint,
+    ]
+
+    reqs, msgs = _utils.validate_constraints(constraints)
+    assert "updated existing" in f"{msgs[extra_constraint]}"
+    assert "updated existing" in f"{msgs[marker_valid_constraint]}"
+    assert "not applicable" in f"{msgs[marker_invalid_constraint]}"
+
 
 def test_validate_constraints_invalid(invalid_constraint):
     reqs, msgs = _utils.validate_constraints([invalid_constraint])
     assert not reqs
     for constraint, msg in msgs.items():
-        msg = msgs[constraint]
-        assert INVALID_CONSTRAINT_MESSAGES[constraint] in msg
+        assert INVALID_CONSTRAINT_MESSAGES[constraint] in f"{msg}"
 
 
 def test_constrain_requirement(valid_constraint):


### PR DESCRIPTION
## references
- fixes #175

## changes
- [x] add `micropip.set_constraints`
- [x] add `constraints` to the signatures of `install` and `Transaction`
  - [x] per upstream, filter constraints that don't provide enough detail (e.g. Just A Wheel URL)
  - [x] merge specifiers to any requirement if found in the constraints (by canonical name)
- [x] rework `install` to handle constrained indirect dependencies of packages found in `pyodide-lock.json`
  - [x] add `requested_by` to the signatures of many `Transaction` methods
  - [x] capture the full as-requested `Transaction.dependency_graph`
  - [x] install packages in topological order based on graph

## breaking changes
- ~~hopefully none, as it's opt-in, and only adds keyword-only arguments to the already very finicky `install`, etc.~~
    - previously, _all_ packages from `pyodide-lock.json` were unconditionally installed before _any_ resolved wheels
    - now, all installations are handled the same way, waiting for any dependencies to be installed first
    - further, transactions containing cycles of dependencies will fail