### PR TITLE
Remove `pytest.importorskip("packaging")` usage for transaction/installation tests

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -224,7 +224,6 @@ async def test_install_pre(
 
 @pytest.mark.asyncio
 async def test_fetch_wheel_fail(monkeypatch, wheel_base):
-    pytest.importorskip("packaging")
     import micropip
     from micropip import wheelinfo
 

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -19,7 +19,6 @@ from micropip._vendored.packaging.src.packaging.tags import Tag
     ["http:", "https:", "file:", "emfs:", ""],
 )
 def test_parse_wheel_url1(protocol, path):
-    pytest.importorskip("packaging")
     from micropip.transaction import WheelInfo
 
     url = protocol + path
@@ -74,7 +73,6 @@ def create_transaction(Transaction):
 
 @pytest.mark.asyncio
 async def test_add_requirement(wheel_catalog):
-    pytest.importorskip("packaging")
     from micropip.transaction import Transaction
 
     snowballstemmer_wheel = wheel_catalog.get("snowballstemmer")
@@ -94,7 +92,6 @@ async def test_add_requirement(wheel_catalog):
 
 @pytest.mark.asyncio
 async def test_add_requirement_marker(mock_importlib, wheel_base):
-    pytest.importorskip("packaging")
     from micropip.transaction import Transaction
 
     transaction = create_transaction(Transaction)
@@ -130,7 +127,6 @@ async def test_add_requirement_marker(mock_importlib, wheel_base):
 
 @pytest.mark.asyncio
 async def test_add_requirement_query_url(mock_importlib, wheel_base, monkeypatch):
-    pytest.importorskip("packaging")
     from micropip.transaction import Transaction
 
     async def mock_add_wheel(self, wheel, extras, *, specifier=""):
@@ -147,7 +143,6 @@ async def test_add_requirement_query_url(mock_importlib, wheel_base, monkeypatch
 
 @pytest.mark.asyncio
 async def test_install_non_pure_python_wheel():
-    pytest.importorskip("packaging")
     from micropip.transaction import Transaction
 
     msg = "Wheel platform 'macosx_10_9_intel' is not compatible with Pyodide's platform"
@@ -188,7 +183,6 @@ def _pypi_metadata(package, versions_to_tags):
 
 
 def test_last_version_from_pypi():
-    pytest.importorskip("packaging")
     from micropip._vendored.packaging.src.packaging.requirements import Requirement
     from micropip.transaction import find_wheel
 
@@ -208,7 +202,6 @@ def test_find_wheel_invalid_version():
 
     it should be skipped instead of producing an error
     """
-    pytest.importorskip("packaging")
     from micropip._vendored.packaging.src.packaging.requirements import Requirement
     from micropip.transaction import find_wheel
 
@@ -243,7 +236,6 @@ _best_tag_test_cases = (
 
 @pytest.mark.parametrize(*_best_tag_test_cases)
 def test_best_tag_from_pypi(package, version, incompatible_tags, compatible_tags):
-    pytest.importorskip("packaging")
     from micropip._vendored.packaging.src.packaging.requirements import Requirement
     from micropip.transaction import find_wheel
 
@@ -277,7 +269,6 @@ def test_best_tag_from_pypi(package, version, incompatible_tags, compatible_tags
 def test_last_version_and_best_tag_from_pypi(
     package, old_version, new_version, old_tags, new_tags
 ):
-    pytest.importorskip("packaging")
     from micropip._vendored.packaging.src.packaging.requirements import Requirement
     from micropip.transaction import find_wheel
 


### PR DESCRIPTION
## Description

This is a remnant of #178. We can now remove the `pytest.importorskip("packaging")` calls, as the check is redundant and the packaging API is available.