### PR TITLE
Unpin `pypa/build`, `pyodide-lock`, and `pytest` for testing requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ test = [
   "pytest-pyodide",
   "pytest-cov",
   "pytest<8.0.0",
-  "build==0.7.0",
+  "build",
   "pyodide-lock==v0.1.0a8",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ test = [
   "pytest-httpserver",
   "pytest-pyodide",
   "pytest-cov",
-  "pytest<8.0.0",
+  "pytest",
   "build",
   "pyodide-lock",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ test = [
   "pytest-cov",
   "pytest<8.0.0",
   "build",
-  "pyodide-lock==v0.1.0a8",
+  "pyodide-lock",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,9 +52,12 @@ def _build(build_dir, dist_dir):
     from build.env import DefaultIsolatedEnv
 
     with DefaultIsolatedEnv() as env:
-        builder = build.ProjectBuilder(build_dir)
-        builder.python_executable = env.executable
-        builder.scripts_dir = env.scripts_dir
+        # https://build.pypa.io/en/stable/api.html#build.ProjectBuilder
+        builder = build.ProjectBuilder(
+            source_dir=build_dir,
+            python_executable=env.python_executable,
+        )
+
         env.install(builder.build_system_requires)
         builder.build("wheel", output_directory=dist_dir)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,9 +49,9 @@ def _read_gzipped_testfile(file: Path) -> bytes:
 
 def _build(build_dir, dist_dir):
     import build
-    from build.env import IsolatedEnvBuilder
+    from build.env import DefaultIsolatedEnv
 
-    with IsolatedEnvBuilder() as env:
+    with DefaultIsolatedEnv() as env:
         builder = build.ProjectBuilder(build_dir)
         builder.python_executable = env.executable
         builder.scripts_dir = env.scripts_dir


### PR DESCRIPTION
## Description

This pull request unpins:
- `pypa/build`, as we were using a very old version, and we were not the same version as what `pyodide-build` uses;
    - fixes compatibility with `build==1.2.2post1` API
- `pyodide-lock`, so that we can be aware when something upstream in `pyodide-lock` changes/fails here; and
- `pytest`, as v8 is reasonably stable now, and the latest version is 8.3.4 at the time of writing.