### PR TITLE
Switch to PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: github.event_name == 'release' && github.event.action == 'published'
-    environment: PyPi-deploy
     permissions:
       id-token: write
       attestations: write
+      contents: read
+    environment:
+      name: pypi
+      url: https://pypi.org/p/micropip
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -60,6 +63,3 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Closes #193; the environment name will have to be configured in https://github.com/pyodide/micropip/settings/ and the trusted publishing on PyPI (release workflow name, and GitHub environment name) will have to be configured in https://pypi.org/manage/project/micropip/settings/.

I don't have access to either of these pages, so I'll tag you, @hoodmane or @ryanking13, so that you can do this.