### PR TITLE
MAINT Rename repodata -> lockfile

### DIFF
--- a/micropip/_compat/__init__.py
+++ b/micropip/_compat/__init__.py
@@ -16,9 +16,9 @@ else:
     compatibility_layer = CompatibilityNotInPyodide
 
 
-REPODATA_INFO = compatibility_layer.repodata_info
+LOCKFILE_INFO = compatibility_layer.lockfile_info
 
-REPODATA_PACKAGES = compatibility_layer.repodata_packages
+LOCKFILE_PACKAGES = compatibility_layer.lockfile_packages
 
 fetch_bytes = compatibility_layer.fetch_bytes
 
@@ -38,8 +38,8 @@ HttpStatusError = compatibility_layer.HttpStatusError
 
 
 __all__ = [
-    "REPODATA_INFO",
-    "REPODATA_PACKAGES",
+    "LOCKFILE_INFO",
+    "LOCKFILE_PACKAGES",
     "fetch_bytes",
     "fetch_string_and_headers",
     "loadedPackages",

--- a/micropip/_compat/_compat_in_pyodide.py
+++ b/micropip/_compat/_compat_in_pyodide.py
@@ -19,8 +19,8 @@ try:
         loadDynlibsFromPackage,
     )
 
-    REPODATA_PACKAGES = pyodide_js._api.repodata_packages.to_py()
-    REPODATA_INFO = pyodide_js._api.repodata_info.to_py()
+    LOCKFILE_PACKAGES = pyodide_js._api.lockfile_packages.to_py()
+    LOCKFILE_INFO = pyodide_js._api.lockfile_info.to_py()
 except ImportError:
     if IN_BROWSER:
         raise
@@ -72,6 +72,6 @@ class CompatibilityInPyodide(CompatibilityLayer):
 
     to_js = to_js
 
-    repodata_info = REPODATA_INFO
+    lockfile_info = LOCKFILE_INFO
 
-    repodata_packages = REPODATA_PACKAGES
+    lockfile_packages = LOCKFILE_PACKAGES

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -78,6 +78,6 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
     ) -> Any:
         return obj
 
-    repodata_info = {}
+    lockfile_info = {}
 
-    repodata_packages = {}
+    lockfile_packages = {}

--- a/micropip/_compat/compatibility_layer.py
+++ b/micropip/_compat/compatibility_layer.py
@@ -27,9 +27,9 @@ class CompatibilityLayer(ABC):
         def to_py():
             pass
 
-    repodata_info: dict[str, str]
+    lockfile_info: dict[str, str]
 
-    repodata_packages: dict[str, dict[str, Any]]
+    lockfile_packages: dict[str, dict[str, Any]]
 
     @staticmethod
     @abstractmethod

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -4,7 +4,7 @@ from importlib.metadata import Distribution
 from pathlib import Path
 from sysconfig import get_config_var, get_platform
 
-from ._compat import REPODATA_PACKAGES
+from ._compat import LOCKFILE_PACKAGES
 from ._vendored.packaging.src.packaging.requirements import (
     InvalidRequirement,
     Requirement,
@@ -222,7 +222,7 @@ def fix_package_dependencies(
         List of extras for this package.
 
     """
-    if package_name in REPODATA_PACKAGES:
+    if package_name in LOCKFILE_PACKAGES:
         # don't check things that are in original repository
         return
 

--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -215,7 +215,7 @@ class PackageManager:
             # Install built-in packages
             if pyodide_packages:
                 # Note: branch never happens in out-of-browser testing because in
-                # that case REPODATA_PACKAGES is empty.
+                # that case LOCKFILE_PACKAGES is empty.
                 await asyncio.ensure_future(
                     self.compat_layer.loadPackage(
                         self.compat_layer.to_js(
@@ -272,8 +272,8 @@ class PackageManager:
             if name in packages:
                 continue
 
-            if name in self.compat_layer.repodata_packages:
-                version = self.compat_layer.repodata_packages[name]["version"]
+            if name in self.compat_layer.lockfile_packages:
+                version = self.compat_layer.lockfile_packages[name]["version"]
                 source_ = "pyodide"
                 if pkg_source != "default channel":
                     # Pyodide package loaded from a custom URL
@@ -298,7 +298,7 @@ class PackageManager:
         ``lockFileURL`` of :js:func:`~globalThis.loadPyodide`.
         """
         return freeze_lockfile(
-            self.compat_layer.repodata_packages, self.compat_layer.repodata_info
+            self.compat_layer.lockfile_packages, self.compat_layer.lockfile_info
         )
 
     def add_mock_package(

--- a/micropip/transaction.py
+++ b/micropip/transaction.py
@@ -7,7 +7,7 @@ from importlib.metadata import PackageNotFoundError
 from urllib.parse import urlparse
 
 from . import package_index
-from ._compat import REPODATA_PACKAGES
+from ._compat import LOCKFILE_PACKAGES
 from ._utils import (
     best_compatible_tag_index,
     check_compatible,
@@ -207,9 +207,9 @@ class Transaction:
         Find requirement from pyodide-lock.json. If the requirement is found,
         add it to the package list and return True. Otherwise, return False.
         """
-        locked_package = REPODATA_PACKAGES.get(req.name)
+        locked_package = LOCKFILE_PACKAGES.get(req.name)
         if locked_package and req.specifier.contains(
-            REPODATA_PACKAGES[req.name]["version"], prereleases=True
+            LOCKFILE_PACKAGES[req.name]["version"], prereleases=True
         ):
             version = locked_package["version"]
             self.pyodide_packages.append(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -322,11 +322,11 @@ async def test_load_binary_wheel1(
 @pytest.mark.skip_refcount_check
 @run_in_pyodide(packages=["micropip"])
 async def test_load_binary_wheel2(selenium_standalone_micropip):
-    from pyodide_js._api import repodata_packages
+    from pyodide_js._api import lockfile_packages
 
     import micropip
 
-    await micropip.install(repodata_packages.regex.file_name)
+    await micropip.install(lockfile_packages.regex.file_name)
     import regex  # noqa: F401
 
 


### PR DESCRIPTION
As title, after this change (and after releasing Pyodide), we can now drop the duplicated exports:

https://github.com/pyodide/pyodide/blob/41c53a05d3827883b64f48fd2ba3302c86413c93/src/js/types.ts#L469-L472