### PR TITLE
Use Pyodide 0.28 alpha for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        pyodide-version: ["0.27.2"]
+        pyodide-version: ["0.28.0a2"]
         test-config: [
             # FIXME: recent version of chrome gets timeout
             { runner: selenium, runtime: chrome, runtime-version: "125" },
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - uses: pyodide/pyodide-actions/download-pyodide@012fa537869d343726d01863a34b773fc4d96a14 # v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       # IMPORTANT: always build sdist, and then the wheel from
       # the sdist (like it is currently done here). This is

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: "3.12"
+  python: "3.13"
 
 exclude: (^micropip/_vendored|^tests/vendored|^tests/test_data)
 repos:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,4 +20,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.12", None),
+    "python": ("https://docs.python.org/3.13", None),
     "pyodide": ("https://pyodide.org/en/stable/", None),
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 description = "A lightweight Python package installer for the web"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
@@ -66,7 +66,7 @@ known-first-party = [
 
 [tool.mypy]
 exclude = ["micropip/_vendored/"]
-python_version = "3.12"
+python_version = "3.13"
 show_error_codes = true
 warn_unreachable = true
 ignore_missing_imports = true

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -360,7 +360,7 @@ def test_emfs_error(selenium_standalone_micropip):
     async def run_test(selenium):
         import micropip
 
-        await micropip.install("emfs:a-2.0.2-cp312-cp312-pyodide_2024_0_wasm32.whl")
+        await micropip.install("emfs:a-2.0.2-cp313-cp313-pyodide_2024_0_wasm32.whl")
 
     with pytest.raises(
         FileNotFoundError,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -360,11 +360,11 @@ def test_emfs_error(selenium_standalone_micropip):
     async def run_test(selenium):
         import micropip
 
-        await micropip.install("emfs:a-2.0.2-cp313-cp313-pyodide_2024_0_wasm32.whl")
+        await micropip.install("emfs:a-2.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl")
 
     with pytest.raises(
         FileNotFoundError,
-        match="No such file or directory: 'a-2.0.2-cp312-cp312-pyodide_2024_0_wasm32.whl'",
+        match="No such file or directory: 'a-2.0.2-cp313-cp313-pyodide_2025_0_wasm32.whl'",
     ):
         run_test(selenium_standalone_micropip)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,12 +108,12 @@ def test_check_compatible(mock_platform, interp, abi, arch, ctx):
 @run_in_pyodide
 def test_check_compatible_wasm32(selenium_standalone_micropip):
     """
-    Here we check in particular that pyodide_2024_0_wasm32 wheels are seen as
+    Here we check in particular that pyodide_2025_0_wasm32 wheels are seen as
     compatible as the platform is emscripten
     """
     from micropip._utils import check_compatible
 
-    wheel_name = "pywavelets-1.8.0.dev0-cp312-cp312-pyodide_2024_0_wasm32.whl"
+    wheel_name = "pywavelets-1.8.0.dev0-cp313-cp313-pyodide_2025_0_wasm32.whl"
     check_compatible(wheel_name)
 
 


### PR DESCRIPTION
Updates the Pyodide version used in CI. I'll open follow-up PRs to adopt APIs from Pyodide 0.28.