### PR TITLE
Replace loadDynlibsFromPackage and get_dynlibs with `install` API

### DIFF
--- a/micropip/_compat/__init__.py
+++ b/micropip/_compat/__init__.py
@@ -15,6 +15,7 @@ else:
 
     compatibility_layer = CompatibilityNotInPyodide
 
+install = compatibility_layer.install
 
 LOCKFILE_INFO = compatibility_layer.lockfile_info
 
@@ -26,11 +27,7 @@ fetch_string_and_headers = compatibility_layer.fetch_string_and_headers
 
 loadedPackages = compatibility_layer.loadedPackages
 
-loadDynlibsFromPackage = compatibility_layer.loadDynlibsFromPackage
-
 loadPackage = compatibility_layer.loadPackage
-
-get_dynlibs = compatibility_layer.get_dynlibs
 
 to_js = compatibility_layer.to_js
 
@@ -40,12 +37,11 @@ HttpStatusError = compatibility_layer.HttpStatusError
 __all__ = [
     "LOCKFILE_INFO",
     "LOCKFILE_PACKAGES",
+    "install",
     "fetch_bytes",
     "fetch_string_and_headers",
     "loadedPackages",
-    "loadDynlibsFromPackage",
     "loadPackage",
-    "get_dynlibs",
     "to_js",
     "HttpStatusError",
 ]

--- a/micropip/_compat/_compat_in_pyodide.py
+++ b/micropip/_compat/_compat_in_pyodide.py
@@ -1,11 +1,6 @@
 from pathlib import Path
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-if TYPE_CHECKING:
-    pass
-
-from pyodide._package_loader import get_dynlibs
 from pyodide.ffi import IN_BROWSER, to_js
 from pyodide.http import HttpStatusError, pyfetch
 
@@ -15,8 +10,8 @@ try:
     import pyodide_js
     from pyodide_js import loadedPackages, loadPackage
     from pyodide_js._api import (  # type: ignore[import]
+        install,
         loadBinaryFile,
-        loadDynlibsFromPackage,
     )
 
     LOCKFILE_PACKAGES = pyodide_js._api.lockfile_packages.to_py()
@@ -64,9 +59,7 @@ class CompatibilityInPyodide(CompatibilityLayer):
 
     loadedPackages = loadedPackages
 
-    get_dynlibs = get_dynlibs
-
-    loadDynlibsFromPackage = loadDynlibsFromPackage
+    install = install
 
     loadPackage = loadPackage
 

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -1,8 +1,10 @@
+import io
 import re
 from typing import IO, Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 from urllib.response import addinfourl
+import zipfile
 
 from .compatibility_layer import CompatibilityLayer
 
@@ -57,7 +59,8 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
         """
         Install a package from a buffer to the specified directory.
         """
-        pass
+        with zipfile.ZipFile(io.BytesIO(buffer)) as zf:
+            zf.extractall(filename)
 
     @staticmethod
     async def loadPackage(names: str | list[str]) -> None:

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -74,6 +74,8 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
             for k, v in metadata.items():
                 (dist_path / k).write_text(v)
 
+        importlib.invalidate_caches()
+
     @staticmethod
     async def loadPackage(names: str | list[str]) -> None:
         pass

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -53,7 +53,7 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
 
     @staticmethod
     async def install(
-        buffer: IO[bytes],
+        buffer: Any,
         filename: str,
         install_dir: str,
         metadata: dict[str, str] | None = None,
@@ -70,13 +70,15 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
         if not metadata:
             return
 
-        pkgname = filename.split("-")[0]
+        pkgname = filename.split("-")[0].lower()
         for dist in distributions():
             if dist.name.lower() != pkgname:
                 continue
 
             for k, v in metadata.items():
-                (dist._path / k).write_text(v)
+                (dist._path / k).write_text(v)  # type: ignore[attr-defined]
+
+            break
 
     @staticmethod
     async def loadPackage(names: str | list[str]) -> None:

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -1,14 +1,10 @@
 import re
-from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 from urllib.response import addinfourl
 
 from .compatibility_layer import CompatibilityLayer
-
-if TYPE_CHECKING:
-    from ..wheelinfo import PackageData
 
 
 class CompatibilityNotInPyodide(CompatibilityLayer):
@@ -52,13 +48,15 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
         return response.read().decode(), headers
 
     @staticmethod
-    def get_dynlibs(archive: IO[bytes], suffix: str, target_dir: Path) -> list[str]:
-        return []
-
-    @staticmethod
-    async def loadDynlibsFromPackage(
-        pkg_metadata: "PackageData", dynlibs: list[str]
+    async def install(
+        buffer: IO[bytes],
+        filename: str,
+        install_dir: str,
+        metadata: dict[str, str] | None = None,
     ) -> None:
+        """
+        Install a package from a buffer to the specified directory.
+        """
         pass
 
     @staticmethod

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -60,7 +60,7 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
         Install a package from a buffer to the specified directory.
         """
         with zipfile.ZipFile(io.BytesIO(buffer)) as zf:
-            zf.extractall(filename)
+            zf.extractall(install_dir)
 
     @staticmethod
     async def loadPackage(names: str | list[str]) -> None:

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -1,5 +1,6 @@
 import importlib
 import io
+from pathlib import Path
 import re
 import zipfile
 from importlib.metadata import distributions
@@ -66,19 +67,12 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
         with zipfile.ZipFile(io.BytesIO(buffer)) as zf:
             zf.extractall(install_dir)
 
-        importlib.invalidate_caches()
-        if not metadata:
-            return
+        dist_dir = f"{'-'.join(filename.split('-')[2])}.dist-info"
+        dist_path = Path(install_dir) / dist_dir
 
-        pkgname = filename.split("-")[0].lower()
-        for dist in distributions():
-            if dist.name.lower() != pkgname:
-                continue
-
+        if metadata:
             for k, v in metadata.items():
-                (dist._path / k).write_text(v)  # type: ignore[attr-defined]
-
-            break
+                (dist_path / k).write_text(v)
 
     @staticmethod
     async def loadPackage(names: str | list[str]) -> None:

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -67,7 +67,7 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
         with zipfile.ZipFile(io.BytesIO(buffer)) as zf:
             zf.extractall(install_dir)
 
-        dist_dir = f"{'-'.join(filename.split('-')[2])}.dist-info"
+        dist_dir = f"{'-'.join(filename.split('-')[:2])}.dist-info"
         dist_path = Path(install_dir) / dist_dir
 
         if metadata:

--- a/micropip/_compat/compatibility_layer.py
+++ b/micropip/_compat/compatibility_layer.py
@@ -42,7 +42,7 @@ class CompatibilityLayer(ABC):
     @staticmethod
     @abstractmethod
     async def install(
-        buffer: IO[bytes],
+        buffer: Any,  # JsBuffer
         filename: str,
         install_dir: str,
         metadata: dict[str, str] | None = None,

--- a/micropip/_compat/compatibility_layer.py
+++ b/micropip/_compat/compatibility_layer.py
@@ -1,9 +1,5 @@
 from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from ..wheelinfo import PackageData
+from typing import IO, Any
 
 
 class CompatibilityLayer(ABC):
@@ -45,13 +41,11 @@ class CompatibilityLayer(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_dynlibs(archive: IO[bytes], suffix: str, target_dir: Path) -> list[str]:
-        pass
-
-    @staticmethod
-    @abstractmethod
-    async def loadDynlibsFromPackage(
-        pkg_metadata: "PackageData", dynlibs: list[str]
+    async def install(
+        buffer: IO[bytes],
+        filename: str,
+        install_dir: str,
+        metadata: dict[str, str] | None = None,
     ) -> None:
         pass
 

--- a/micropip/_compat/compatibility_layer.py
+++ b/micropip/_compat/compatibility_layer.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import IO, Any
+from typing import Any
 
 
 class CompatibilityLayer(ABC):

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -9,8 +9,7 @@ from urllib.parse import ParseResult, urlparse
 
 from ._compat import (
     fetch_bytes,
-    get_dynlibs,
-    loadDynlibsFromPackage,
+    install,
     loadedPackages,
 )
 from ._utils import parse_wheel_filename
@@ -140,9 +139,7 @@ class WheelInfo:
                 "Micropip internal error: attempted to install wheel before downloading it?"
             )
         _validate_sha256_checksum(self._data, self.sha256)
-        self._extract(target)
-        await self._load_libraries(target)
-        self._set_installer()
+        await self._install(target)
 
     async def download(self, fetch_kwargs: dict[str, Any]):
         if self._data is not None:
@@ -222,48 +219,37 @@ class WheelInfo:
                 ) from e
             raise e
 
-    def _extract(self, target: Path) -> None:
-        assert self._data
-        with zipfile.ZipFile(io.BytesIO(self._data)) as zf:
-            zf.extractall(target)
-            self._dist_info = target / wheel_dist_info_dir(zf, self.name)
-
-    def _set_installer(self) -> None:
-        """
-        Set the installer metadata in the wheel's .dist-info directory.
-        """
-        assert self._data
-        wheel_source = "pypi" if self.sha256 is not None else self.url
-
-        self._write_dist_info("PYODIDE_SOURCE", wheel_source)
-        self._write_dist_info("PYODIDE_URL", self.url)
-        self._write_dist_info("PYODIDE_SHA256", _generate_package_hash(self._data))
-        self._write_dist_info("INSTALLER", "micropip")
-        if self._requires:
-            self._write_dist_info(
-                "PYODIDE_REQUIRES", json.dumps(sorted(x.name for x in self._requires))
-            )
-
-        setattr(loadedPackages, self._project_name, wheel_source)
-
     def _write_dist_info(self, file: str, content: str) -> None:
         assert self._dist_info
         (self._dist_info / file).write_text(content)
 
-    async def _load_libraries(self, target: Path) -> None:
+    async def _install(self, target: Path) -> None:
         """
-        Compiles shared libraries (WASM modules) in the wheel and loads them.
+        Install the wheel to the target directory.
         """
         assert self._data
 
-        pkg = PackageData(
-            file_name=self.filename,
-            package_type="package",
-            shared_library=False,
+        wheel_source = "pypi" if self.sha256 is not None else self.url
+        metadata = {
+            "PYODIDE_SOURCE": wheel_source,
+            "PYODIDE_URL": self.url,
+            "PYODIDE_SHA256": _generate_package_hash(self._data),
+            "INSTALLER": "micropip",
+        }
+
+        if self._requires:
+            metadata["PYODIDE_REQUIRES"] = json.dumps(
+                sorted(x.name for x in self._requires)
+            )
+
+        await install(
+            self._data,
+            self.filename,
+            str(target),
+            metadata=metadata,
         )
 
-        dynlibs = get_dynlibs(io.BytesIO(self._data), ".whl", target)
-        await loadDynlibsFromPackage(pkg, dynlibs)
+        setattr(loadedPackages, self._project_name, wheel_source)
 
 
 def _validate_sha256_checksum(data: bytes, expected: str | None = None) -> None:

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -53,10 +53,6 @@ class WheelInfo:
     _metadata: Metadata | None = None  # Wheel metadata.
     _requires: list[Requirement] | None = None  # List of requirements.
 
-    # Path to the .dist-info directory.
-    # This is only available after extracting the wheel, i.e. after calling `extract()`.
-    _dist_info: Path | None = None
-
     def __post_init__(self):
         assert (
             self.url.startwith(p) for p in ("http:", "https:", "emfs:", "file:")
@@ -218,10 +214,6 @@ class WheelInfo:
                     "Check if the server is sending the correct 'Access-Control-Allow-Origin' header."
                 ) from e
             raise e
-
-    def _write_dist_info(self, file: str, content: str) -> None:
-        assert self._dist_info
-        (self._dist_info / file).write_text(content)
 
     async def _install(self, target: Path) -> None:
         """

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -236,10 +236,11 @@ class WheelInfo:
             )
 
         await install(
+            # TODO: Probably update install API to accept bytes directly, instead of converting it to JS.
             to_js(self._data),
             self.filename,
             str(target),
-            metadata=metadata,
+            metadata,
         )
 
         setattr(loadedPackages, self._project_name, wheel_source)

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -11,6 +11,7 @@ from ._compat import (
     fetch_bytes,
     install,
     loadedPackages,
+    to_js,
 )
 from ._utils import parse_wheel_filename
 from ._vendored.packaging.src.packaging.requirements import Requirement
@@ -235,7 +236,7 @@ class WheelInfo:
             )
 
         await install(
-            self._data,
+            to_js(self._data),
             self.filename,
             str(target),
             metadata=metadata,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -124,3 +124,27 @@ def test_integration_freeze_basic(selenium_standalone_micropip, pytestconfig):
         assert "snowballstemmer" in json.loads(lockfile)["packages"]
 
     _run(selenium_standalone_micropip)
+
+
+@integration_test_only
+def test_installer(selenium_standalone_micropip, pytestconfig):
+
+    @run_in_pyodide
+    async def _run(selenium):
+        import micropip
+
+        await micropip.install("snowballstemmer")
+
+        from importlib.metadata import distribution
+
+        dummy_wheel = distribution("snowballstemmer")
+        assert dummy_wheel.name == "snowballstemmer"
+
+        dist_dir = dummy_wheel._dist_info
+
+        assert (dist_dir / "INSTALLER").read_text() == "micropip"
+        assert (dist_dir / "PYODIDE_SOURCE").read_text() == dummy_wheel.url
+        assert (dist_dir / "PYODIDE_URL").read_text() == dummy_wheel.url
+        assert (dist_dir / "PYODIDE_SHA256").exists()
+
+    _run(selenium_standalone_micropip)

--- a/tests/test_wheelinfo.py
+++ b/tests/test_wheelinfo.py
@@ -55,7 +55,7 @@ async def test_requires(wheel_catalog, tmp_path):
     wheel = WheelInfo.from_url(pytest_wheel.url)
     await wheel.download({})
 
-    wheel._extract(tmp_path)
+    wheel._install(tmp_path)
 
     requirements_default = [str(r.name) for r in wheel.requires(set())]
     assert "pluggy" in requirements_default

--- a/tests/test_wheelinfo.py
+++ b/tests/test_wheelinfo.py
@@ -37,35 +37,6 @@ def test_from_package_index():
     assert wheel.core_metadata == core_metadata
 
 
-def test_extract(wheel_catalog, tmp_path):
-    pytest_wheel = wheel_catalog.get("pytest")
-    dummy_wheel = WheelInfo.from_url(pytest_wheel.url)
-    dummy_wheel._data = pytest_wheel.content
-
-    dummy_wheel._extract(tmp_path)
-    assert dummy_wheel._dist_info is not None
-    assert dummy_wheel._dist_info.is_dir()
-
-
-def test_set_installer(wheel_catalog, tmp_path):
-    pytest_wheel = wheel_catalog.get("pytest")
-    dummy_wheel = WheelInfo.from_url(pytest_wheel.url)
-    dummy_wheel._data = pytest_wheel.content
-
-    dummy_wheel._extract(tmp_path)
-
-    dummy_wheel._set_installer()
-
-    assert (dummy_wheel._dist_info / "INSTALLER").read_text() == "micropip"
-    assert (dummy_wheel._dist_info / "PYODIDE_SOURCE").read_text() == dummy_wheel.url
-    assert (dummy_wheel._dist_info / "PYODIDE_URL").read_text() == dummy_wheel.url
-    assert (dummy_wheel._dist_info / "PYODIDE_SHA256").exists()
-
-
-def test_install():
-    pass
-
-
 @pytest.mark.asyncio
 async def test_download(wheel_catalog):
     pytest_wheel = wheel_catalog.get("pytest")


### PR DESCRIPTION
This PR adopts `install` function (https://github.com/pyodide/pyodide/issues/4914), which is a stable API for installing packages that Pyodide runtime provides.

It replaces other compatibility functions such as `loadDynlibsFromPackage` and `get_dynlibs`, and removes duplicate codes.