### PR TITLE
Replace relative URLs to absolute URL when freezing the lockfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        pyodide-version: ["0.28.0a2"]
+        pyodide-version: ["0.28.0"]
         test-config: [
             # FIXME: recent version of chrome gets timeout
             { runner: selenium, runtime: chrome, runtime-version: "125" },

--- a/micropip/_compat/__init__.py
+++ b/micropip/_compat/__init__.py
@@ -21,6 +21,8 @@ LOCKFILE_INFO = compatibility_layer.lockfile_info
 
 LOCKFILE_PACKAGES = compatibility_layer.lockfile_packages
 
+lockfile_base_url = compatibility_layer.lockfile_base_url
+
 fetch_bytes = compatibility_layer.fetch_bytes
 
 fetch_string_and_headers = compatibility_layer.fetch_string_and_headers
@@ -40,4 +42,5 @@ __all__ = [
     "loadedPackages",
     "loadPackage",
     "to_js",
+    "lockfile_base_url",
 ]

--- a/micropip/_compat/_compat_in_pyodide.py
+++ b/micropip/_compat/_compat_in_pyodide.py
@@ -8,7 +8,7 @@ from .compatibility_layer import CompatibilityLayer
 
 try:
     import pyodide_js
-    from pyodide_js import loadedPackages, loadPackage
+    from pyodide_js import loadedPackages, loadPackage, lockfileBaseUrl
     from pyodide_js._api import (  # type: ignore[import]
         install,
         loadBinaryFile,
@@ -58,3 +58,5 @@ class CompatibilityInPyodide(CompatibilityLayer):
     lockfile_info = LOCKFILE_INFO
 
     lockfile_packages = LOCKFILE_PACKAGES
+
+    lockfile_base_url = lockfileBaseUrl

--- a/micropip/_compat/_compat_not_in_pyodide.py
+++ b/micropip/_compat/_compat_not_in_pyodide.py
@@ -84,3 +84,5 @@ class CompatibilityNotInPyodide(CompatibilityLayer):
     lockfile_info = {}
 
     lockfile_packages = {}
+
+    lockfile_base_url = None

--- a/micropip/_compat/compatibility_layer.py
+++ b/micropip/_compat/compatibility_layer.py
@@ -19,6 +19,8 @@ class CompatibilityLayer(ABC):
 
     lockfile_packages: dict[str, dict[str, Any]]
 
+    lockfile_base_url: str | None = None
+
     @staticmethod
     @abstractmethod
     async def fetch_bytes(url: str, kwargs: dict[str, str]) -> bytes:

--- a/micropip/freeze.py
+++ b/micropip/freeze.py
@@ -23,11 +23,10 @@ def freeze_data(
     lockfile_packages: dict[str, dict[str, Any]], lockfile_info: dict[str, str], lockfile_base_url: str | None = None,
 ) -> dict[str, Any]:
     packages = deepcopy(lockfile_packages)
+    packages.update(load_pip_packages(lockfile_packages))
     if lockfile_base_url is not None:
         # Override the base URL for the packages
         override_base_url(packages, lockfile_base_url)
-
-    packages.update(load_pip_packages(lockfile_packages))
 
     # Sort
     packages = dict(sorted(packages.items()))

--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -320,7 +320,9 @@ class PackageManager:
         ``lockFileURL`` of :js:func:`~globalThis.loadPyodide`.
         """
         return freeze_lockfile(
-            self.compat_layer.lockfile_packages, self.compat_layer.lockfile_info
+            self.compat_layer.lockfile_packages,
+            self.compat_layer.lockfile_info,
+            self.compat_layer.lockfile_base_url,
         )
 
     def add_mock_package(

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -123,9 +123,10 @@ def test_override_base_url():
     assert lockfile_packages["pkg3"]["file_name"] == "https://other.com/pkg3-3.0.0-py3-none-any.whl"
 
 
-@run_in_pyodide
+
 def test_url_after_freeze_pyodide(selenium_standalone_micropip):
 
+    @run_in_pyodide
     def _run(selenium, prefix):
         import json
 
@@ -164,7 +165,7 @@ def test_url_after_freeze_pyodide(selenium_standalone_micropip):
 
     selenium = selenium_standalone_micropip
     prefix = ("/",) if selenium.browser == "node" else ("http://", "https://")
-    selenium.run_async(_run, prefix=prefix)
+    _run(selenium, prefix)
 
         
 

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -152,10 +152,10 @@ def test_url_after_freeze_pyodide(selenium_standalone_micropip):
 
         # original lockfile will have relative URLs
         # TODO: this might change later if packages are served from PyPI
-        assert not orig_pkg["file_name"].startswith("http")
+        assert not orig_pkg["file_name"].startswith(("http://", "https://"))
 
         # new lockfile should have absolute URLs
-        assert new_pkg["file_name"].startswith("http")
+        assert new_pkg["file_name"].startswith(("http://", "https://"))
         assert new_pkg["file_name"].startswith(lockfileBaseUrl)
 
         assert orig_pkg["file_name"] in new_pkg["file_name"]


### PR DESCRIPTION
This updates `micropip.freeze` to replace relative URLs (or just file names) to absolute URL.

This was discussed in https://github.com/pyodide/pyodide/pull/5652#issuecomment-2893609838 but I forgot to fix it before releasing 0.28.

This also fixes https://github.com/pyodide/pyodide/issues/5736