### PR TITLE
CI Use 0.28.0 for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        pyodide-version: ["0.28.0a2"]
+        pyodide-version: ["0.28.0"]
         test-config: [
             # FIXME: recent version of chrome gets timeout
             { runner: selenium, runtime: chrome, runtime-version: "125" },


### PR DESCRIPTION
Splitted out from #241. For some reason, updating the pyodide version in the same PR seems to mess up with caching