### PR TITLE
docs: Add doctest examples to micropip.install function

### DIFF
--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -164,9 +164,6 @@ class PackageManager:
         >>> await micropip.install("snowballstemmer")
         >>> await micropip.install(["snowballstemmer", "mccabe"])
         >>> await micropip.install("numpy>=2.2.0")
-
-        For more details and advanced usage, see the user manual:
-        https://pyodide.org/en/stable/usage/loading-packages.html#micropip
         """
 
         with setup_logging().ctx_level(verbose) as logger:

--- a/micropip/package_manager.py
+++ b/micropip/package_manager.py
@@ -157,6 +157,16 @@ class PackageManager:
             Print more information about the process. By default, micropip does not
             change logger level. Setting ``verbose=True`` will print similar
             information as pip.
+
+        Examples
+        --------
+        >>> import micropip
+        >>> await micropip.install("snowballstemmer")
+        >>> await micropip.install(["snowballstemmer", "mccabe"])
+        >>> await micropip.install("numpy>=2.2.0")
+
+        For more details and advanced usage, see the user manual:
+        https://pyodide.org/en/stable/usage/loading-packages.html#micropip
         """
 
         with setup_logging().ctx_level(verbose) as logger:


### PR DESCRIPTION
Added docstring examples for `micropip.install()`.

I haven’t included any flags (i.e. `# doctest: +RUN_IN_PYODIDE` or `# doctest: +SKIP`) as I assumed the tests for micropip will run within the already-established Pyodide environment. Happy to update if this assumption is incorrect.

This partially addresses issue pyodide/pyodide#1955