### PR TITLE
fix: Handle percent-encoded characters in wheel file URLs

### DIFF
--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -5,7 +5,7 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
-from urllib.parse import ParseResult, urlparse, unquote
+from urllib.parse import ParseResult, unquote, urlparse
 
 from ._compat import (
     fetch_bytes,

--- a/micropip/wheelinfo.py
+++ b/micropip/wheelinfo.py
@@ -5,7 +5,7 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, urlparse, unquote
 
 from ._compat import (
     fetch_bytes,
@@ -78,7 +78,7 @@ class WheelInfo:
                 query=parsed_url.query,
                 fragment=parsed_url.fragment,
             )
-        file_name = Path(parsed_url.path).name
+        file_name = Path(unquote(parsed_url.path)).name
         name, version, build, tags = parse_wheel_filename(file_name)
         return WheelInfo(
             name=name,

--- a/tests/test_wheelinfo.py
+++ b/tests/test_wheelinfo.py
@@ -15,6 +15,19 @@ def test_from_url():
     assert wheel.sha256 is None
 
 
+def test_from_url_with_percent_encoded_path():
+    # Test URL with percent-encoded characters (+ encoded as %2B in version string)
+    url = "https://test.com/dummy_module-1.0.0%2Blocalbuild.1-py3-none-any.whl"
+    wheel = WheelInfo.from_url(url)
+
+    assert wheel.name == "dummy-module"
+    assert str(wheel.version) == "1.0.0+localbuild.1"
+    assert wheel.url == url
+    assert wheel.filename == "dummy_module-1.0.0+localbuild.1-py3-none-any.whl"
+    assert wheel.size is None
+    assert wheel.sha256 is None
+
+
 def test_from_package_index():
     name = "dummy-module"
     filename = "dummy_module-0.0.1-py3-none-any.whl"


### PR DESCRIPTION
- fix #247
