### PR TITLE
Add a subclass to optimize Versions

### DIFF
--- a/micropip/_cached_version.py
+++ b/micropip/_cached_version.py
@@ -2,22 +2,29 @@ from ._vendored.packaging.src.packaging.version import Version
 
 
 class CachedVersion(Version):
-    """This class is a subclass of Version with cached hash and string representations for performance."""
+    """This class is a subclass of Version with a lazily cached string representation for performance."""
 
-    __slots__ = ("_cached_hash", "_cached_str")
+    __slots__ = ("_cached_str",)
 
     def __init__(self, version: str) -> None:
         super().__init__(version)
-
-        # Cache expensive computations
-        self._cached_hash = hash(self._key)
-        self._cached_str = super().__str__()
-
-    def __hash__(self) -> int:
-        return self._cached_hash
+        self._cached_str = None
 
     def __str__(self) -> str:
+        if self._cached_str is None:
+            self._cached_str = super().__str__()
         return self._cached_str
+
+    @classmethod
+    def from_version(cls, version: Version) -> "CachedVersion":
+        """Helper method to create a CachedVersion from an existing Version object."""
+        if isinstance(version, cls):
+            return version
+        instance = cls.__new__(cls)
+        instance._version = version._version
+        instance._key = version._key
+        instance._cached_str = None
+        return instance
 
     def __repr__(self) -> str:
         """A representation of the CachedVersion that shows all internal state.

--- a/micropip/_cached_version.py
+++ b/micropip/_cached_version.py
@@ -1,27 +1,26 @@
-from ._vendored.packaging.src.packaging.version import Version, InvalidVersion
+from ._vendored.packaging.src.packaging.version import InvalidVersion, Version
 
 __all__ = ["CachedVersion", "parse_cached_version", "InvalidVersion"]
 
 
 class CachedVersion(Version):
-    """This class is a subclass of Version with cached hash and string representations for performance.
-    """
-    
-    __slots__ = ('_cached_hash', '_cached_str')
-    
+    """This class is a subclass of Version with cached hash and string representations for performance."""
+
+    __slots__ = ("_cached_hash", "_cached_str")
+
     def __init__(self, version: str) -> None:
         super().__init__(version)
-        
+
         # Cache expensive computations
         self._cached_hash = hash(self._key)
         self._cached_str = super().__str__()
-    
+
     def __hash__(self) -> int:
         return self._cached_hash
-    
+
     def __str__(self) -> str:
         return self._cached_str
-    
+
     def __repr__(self) -> str:
         """A representation of the CachedVersion that shows all internal state.
 

--- a/micropip/_cached_version.py
+++ b/micropip/_cached_version.py
@@ -1,0 +1,45 @@
+from ._vendored.packaging.src.packaging.version import Version, InvalidVersion
+
+__all__ = ["CachedVersion", "parse_cached_version", "InvalidVersion"]
+
+
+class CachedVersion(Version):
+    """This class is a subclass of Version with cached hash and string representations for performance.
+    """
+    
+    __slots__ = ('_cached_hash', '_cached_str')
+    
+    def __init__(self, version: str) -> None:
+        super().__init__(version)
+        
+        # Cache expensive computations
+        self._cached_hash = hash(self._key)
+        self._cached_str = super().__str__()
+    
+    def __hash__(self) -> int:
+        return self._cached_hash
+    
+    def __str__(self) -> str:
+        return self._cached_str
+    
+    def __repr__(self) -> str:
+        """A representation of the CachedVersion that shows all internal state.
+
+        >>> CachedVersion('1.0.0')
+        <CachedVersion('1.0.0')>
+        """
+
+        return f"<CachedVersion('{self}')>"
+
+
+def parse_cached_version(version_str: str) -> CachedVersion:
+    """Parse version string into CachedVersion object.
+    Parameters
+    ----------
+    version_str: str
+        Version string to parse (e.g., "1.2.3", "2.0.0a1")
+    Returns
+    -------
+    CachedVersion object
+    """
+    return CachedVersion(version_str)

--- a/micropip/_cached_version.py
+++ b/micropip/_cached_version.py
@@ -1,6 +1,4 @@
-from ._vendored.packaging.src.packaging.version import InvalidVersion, Version
-
-__all__ = ["CachedVersion", "parse_cached_version", "InvalidVersion"]
+from ._vendored.packaging.src.packaging.version import Version
 
 
 class CachedVersion(Version):
@@ -29,16 +27,3 @@ class CachedVersion(Version):
         """
 
         return f"<CachedVersion('{self}')>"
-
-
-def parse_cached_version(version_str: str) -> CachedVersion:
-    """Parse version string into CachedVersion object.
-    Parameters
-    ----------
-    version_str: str
-        Version string to parse (e.g., "1.2.3", "2.0.0a1")
-    Returns
-    -------
-    CachedVersion object
-    """
-    return CachedVersion(version_str)

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -3,6 +3,7 @@ from importlib.metadata import Distribution
 from pathlib import Path
 from sysconfig import get_config_var, get_platform
 
+from ._cached_version import CachedVersion
 from ._vendored.packaging.src.packaging.requirements import (
     InvalidRequirement,
     Requirement,
@@ -18,7 +19,6 @@ from ._vendored.packaging.src.packaging.utils import (
     parse_wheel_filename as parse_wheel_filename_orig,
 )
 from ._vendored.packaging.src.packaging.version import InvalidVersion, Version
-from ._cached_version import CachedVersion
 
 
 def get_dist_info(dist: Distribution) -> Path:

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -88,7 +88,7 @@ def parse_wheel_filename(
 
 
 # TODO: Move these helper functions back to WheelInfo
-def parse_version(filename: str) -> CachedVersion:
+def parse_version(filename: str) -> Version:
     """Parses a version from a wheel filename, returning a CachedVersion."""
     version_obj = parse_wheel_filename(filename)[1]
     if isinstance(version_obj, CachedVersion):

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -91,9 +91,7 @@ def parse_wheel_filename(
 def parse_version(filename: str) -> Version:
     """Parses a version from a wheel filename, returning a CachedVersion."""
     version_obj = parse_wheel_filename(filename)[1]
-    if isinstance(version_obj, CachedVersion):
-        return version_obj
-    return CachedVersion(str(version_obj))
+    return CachedVersion.from_version(version_obj)
 
 
 def parse_tags(filename: str) -> frozenset[Tag]:

--- a/micropip/_utils.py
+++ b/micropip/_utils.py
@@ -18,6 +18,7 @@ from ._vendored.packaging.src.packaging.utils import (
     parse_wheel_filename as parse_wheel_filename_orig,
 )
 from ._vendored.packaging.src.packaging.version import InvalidVersion, Version
+from ._cached_version import CachedVersion
 
 
 def get_dist_info(dist: Distribution) -> Path:
@@ -87,8 +88,12 @@ def parse_wheel_filename(
 
 
 # TODO: Move these helper functions back to WheelInfo
-def parse_version(filename: str) -> Version:
-    return parse_wheel_filename(filename)[1]
+def parse_version(filename: str) -> CachedVersion:
+    """Parses a version from a wheel filename, returning a CachedVersion."""
+    version_obj = parse_wheel_filename(filename)[1]
+    if isinstance(version_obj, CachedVersion):
+        return version_obj
+    return CachedVersion(str(version_obj))
 
 
 def parse_tags(filename: str) -> frozenset[Tag]:

--- a/micropip/package_index.py
+++ b/micropip/package_index.py
@@ -10,11 +10,11 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 from ._cached_version import CachedVersion
-from ._vendored.packaging.src.packaging.version import InvalidVersion, Version
 from ._compat import CompatibilityLayer
 from ._utils import is_package_compatible, parse_version
 from ._vendored.mousebender.simple import from_project_details_html
 from ._vendored.packaging.src.packaging.utils import InvalidWheelFilename
+from ._vendored.packaging.src.packaging.version import InvalidVersion, Version
 from .types import DistributionMetadata
 from .wheelinfo import WheelInfo
 

--- a/micropip/package_index.py
+++ b/micropip/package_index.py
@@ -9,11 +9,11 @@ from functools import partial
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
+from ._cached_version import CachedVersion, InvalidVersion, parse_cached_version
 from ._compat import CompatibilityLayer
 from ._utils import is_package_compatible, parse_version
 from ._vendored.mousebender.simple import from_project_details_html
 from ._vendored.packaging.src.packaging.utils import InvalidWheelFilename
-from ._vendored.packaging.src.packaging.version import InvalidVersion, Version
 from .types import DistributionMetadata
 from .wheelinfo import WheelInfo
 
@@ -39,7 +39,7 @@ class ProjectInfo:
     # List of releases available for the package, sorted in ascending order by version.
     # For each version, list of wheels compatible with the current platform are stored.
     # If no such wheel is available, the list is empty.
-    releases: dict[Version, Generator[WheelInfo, None, None]]
+    releases: dict[CachedVersion, Generator[WheelInfo, None, None]]
 
     @staticmethod
     def from_json_api(data: str | bytes | dict[str, Any]) -> "ProjectInfo":
@@ -55,7 +55,7 @@ class ProjectInfo:
         releases_raw: dict[str, list[Any]] = data_dict["releases"]
 
         # Filter out non PEP 440 compliant versions
-        releases: dict[Version, list[Any]] = {}
+        releases: dict[CachedVersion, list[Any]] = {}
         for version_str, fileinfo in releases_raw.items():
             version, ok = _is_valid_pep440_version(version_str)
             if not ok or not version:
@@ -99,7 +99,7 @@ class ProjectInfo:
     @staticmethod
     def _parse_pep691_response(
         resp: dict[str, Any], index_base_url: str
-    ) -> tuple[str, dict[Version, list[Any]]]:
+    ) -> tuple[str, dict[CachedVersion, list[Any]]]:
         name = resp["name"]
 
         # List of versions (PEP 700), this key is not critical to find packages
@@ -109,7 +109,7 @@ class ProjectInfo:
         versions = resp.get("versions", [])
 
         # Group files by version
-        releases: dict[Version, list[Any]] = defaultdict(list)
+        releases: dict[CachedVersion, list[Any]] = defaultdict(list)
 
         for version_str in versions:
             version, ok = _is_valid_pep440_version(version_str)
@@ -140,7 +140,7 @@ class ProjectInfo:
 
     @classmethod
     def _compatible_wheels(
-        cls, files: list[dict[str, Any]], version: Version, name: str
+        cls, files: list[dict[str, Any]], version: CachedVersion, name: str
     ) -> Generator[WheelInfo, None, None]:
         for file in files:
             filename = file["filename"]
@@ -181,7 +181,7 @@ class ProjectInfo:
 
     @classmethod
     def _compatible_only(
-        cls, name: str, releases: dict[Version, list[dict[str, Any]]]
+        cls, name: str, releases: dict[CachedVersion, list[dict[str, Any]]]
     ) -> "ProjectInfo":
         """
         Return a generator of wheels compatible with the current platform.
@@ -204,14 +204,14 @@ class ProjectInfo:
         )
 
 
-def _is_valid_pep440_version(version_str: str) -> tuple[Version | None, bool]:
+def _is_valid_pep440_version(version_str: str) -> tuple[CachedVersion | None, bool]:
     """
     Check if the given string is a valid PEP 440 version.
-    Since parsing a version is expensive, we return the parsed version as well,
+    Since parsing a version is expensive, we return the parsed cached version as well,
     so that it can be reused if needed.
     """
     try:
-        version = Version(version_str)
+        version = parse_cached_version(version_str)
         return version, True
     except InvalidVersion:
         return None, False

--- a/tests/test_cached_version.py
+++ b/tests/test_cached_version.py
@@ -1,26 +1,25 @@
-
 import pytest
+
 from micropip._cached_version import CachedVersion
 from micropip._vendored.packaging.src.packaging.version import Version
 
 
-@pytest.mark.parametrize("version1, version2", [
-    ("1.0.0", "1.0.1"),
-    ("1.0a0", "1.0a1"),
-    ("1.0.0rc1", "1.0.0rc2")
-])
+@pytest.mark.parametrize(
+    "version1, version2",
+    [("1.0.0", "1.0.1"), ("1.0a0", "1.0a1"), ("1.0.0rc1", "1.0.0rc2")],
+)
 def test_equal_behavior(version1, version2):
     """Check equal behavior between Version and CachedVersion"""
-    original = Version(version1) 
+    original = Version(version1)
     cached = CachedVersion(version1)
     different = CachedVersion(version2)
-        
+
     assert original == cached
     assert cached == original
     assert cached != different
-        
+
     assert hash(original) == hash(cached)
-        
+
     version_set = {original, cached}
     assert len(version_set) == 1, "Equal versions should deduplicate in sets"
 
@@ -28,13 +27,15 @@ def test_equal_behavior(version1, version2):
 def test_consistency_invariants():
     """Check that the caching doesn't break consistency"""
     obj = CachedVersion("1.0.0")
-    
+
     hashes = [hash(obj) for _ in range(5)]
     strings = [str(obj) for _ in range(5)]
-        
+
     assert all(h == hashes[0] for h in hashes), "Hash should be consistent across calls"
-    assert all(s == strings[0] for s in strings), "String should be consistent across calls"
-    
+    assert all(
+        s == strings[0] for s in strings
+    ), "String should be consistent across calls"
+
     version_set = {obj, CachedVersion("1.0.0")}
     assert len(version_set) == 1, "Identical cached versions should deduplicate"
 

--- a/tests/test_cached_version.py
+++ b/tests/test_cached_version.py
@@ -1,0 +1,44 @@
+
+import pytest
+from micropip._cached_version import CachedVersion
+from micropip._vendored.packaging.src.packaging.version import Version
+
+
+@pytest.mark.parametrize("version1, version2", [
+    ("1.0.0", "1.0.1"),
+    ("1.0a0", "1.0a1"),
+    ("1.0.0rc1", "1.0.0rc2")
+])
+def test_equal_behavior(version1, version2):
+    """Check equal behavior between Version and CachedVersion"""
+    original = Version(version1) 
+    cached = CachedVersion(version1)
+    different = CachedVersion(version2)
+        
+    assert original == cached
+    assert cached == original
+    assert cached != different
+        
+    assert hash(original) == hash(cached)
+        
+    version_set = {original, cached}
+    assert len(version_set) == 1, "Equal versions should deduplicate in sets"
+
+
+def test_consistency_invariants():
+    """Check that the caching doesn't break consistency"""
+    obj = CachedVersion("1.0.0")
+    
+    hashes = [hash(obj) for _ in range(5)]
+    strings = [str(obj) for _ in range(5)]
+        
+    assert all(h == hashes[0] for h in hashes), "Hash should be consistent across calls"
+    assert all(s == strings[0] for s in strings), "String should be consistent across calls"
+    
+    version_set = {obj, CachedVersion("1.0.0")}
+    assert len(version_set) == 1, "Identical cached versions should deduplicate"
+
+    other_instance = CachedVersion("1.0.0")
+    assert obj == other_instance
+    assert hash(obj) == hash(other_instance)
+    assert str(obj) == str(other_instance)


### PR DESCRIPTION
This PR adds class `CachedVersion`, a subclass of `packaging.version.Version` which caches its hash and string representations to avoid re-computation at each comparison.

This closes #73.